### PR TITLE
chore: configure SOURCE_BUCKET

### DIFF
--- a/ci/generate.cfg
+++ b/ci/generate.cfg
@@ -20,6 +20,12 @@ env_vars: {
     value: "./generate.sh"
 }
 
+# Which bucket to read and write tarballs.
+env_vars: {
+    key: "SOURCE_BUCKET"
+    value: "docs-staging-v2-staging"
+}
+
 before_action {
   fetch_keystore {
     keystore_resource {


### PR DESCRIPTION
The docuploader service account (which this runs as) doesn't have all of
the right permissions on this bucket yet. So, this may get a permission
denied error until the permissions are updated.