### PR TITLE
feat: clone and use doc-templates devsite template

### DIFF
--- a/docfx/Dockerfile
+++ b/docfx/Dockerfile
@@ -18,7 +18,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PATH ${PATH}:/opt/docfx
 
 RUN apt-get update && \
-    apt-get -y install gnupg ca-certificates wget zip python3 python3-pip
+    apt-get -y install gnupg ca-certificates wget zip python3 python3-pip git
 
 # Install mono with the instructions at:
 # https://www.mono-project.com/download/stable/#download-lin

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -92,4 +92,8 @@ def test_generate(yaml_dir, tmpdir):
     tar.decompress(tar_path, tmpdir)
     assert tmpdir.join("docs.metadata").isfile()
     assert tmpdir.join("_toc.yaml").isfile()
-    assert tmpdir.join("google.api.customhttppattern.html").isfile()
+
+    html_file_path = tmpdir.join("google.api.customhttppattern.html")
+    assert html_file_path.isfile()
+    got_text = html_file_path.read_text("utf-8")
+    assert "devsite" in got_text


### PR DESCRIPTION
There are a few benefits of doing it this way:
* Tests can confirm that the template is properly applied.
* If you run doc-pipeline locally, the templates work without any special directory setup.
* If you clone in generate.sh, tests can't confirm the template is applied (since they don't go through generate.sh).