### PR TITLE
feat: add ability to regenerate all or one tarball

### DIFF
--- a/.trampolinerc
+++ b/.trampolinerc
@@ -18,8 +18,10 @@ required_envvars+=(
 
 # Add env vars which are passed down into the container here.
 pass_down_envvars+=(
-    "SOURCE_BUCKET"
-    "TEST_BUCKET"
+    "SOURCE_BUCKET"      # Must set to generate any docs.
+    "SOURCE_BLOB"        # Set to force regeneration of a single source blob.
+    "FORCE_GENERATE_ALL" # Set to force regeneration of all blobs.
+    "TEST_BUCKET"        # Must set when running tests.
 )
 
 # Prevent unintentional override on the default image.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Google Cloud Platform document pipeline
 
+## Environment variables
+
+See `.trampolinerc` for the canonical list of relevant environment variables.
+
+* `TESTING_BUCKET`: Set when running tests. See the Testing section.
+* `SOURCE_BUCKET`: The bucket to use for regeneration. See Running locally.
+* `SOURCE_BLOB`: A single blob to regenerate. Only the blob name - do not
+  include `gs://` or the bucket.
+* `FORCE_GENERATE_ALL`: Set to `true` to regenerate all docs.
+
 ## Formatting and style
 
 Formatting is done with `black` and style is verified with `flake8`.

--- a/docpipeline/__main__.py
+++ b/docpipeline/__main__.py
@@ -30,20 +30,7 @@ REQUIRED_CMDS = ["docfx", "docuploader"]
 VERSION = "0.0.0-dev"
 
 
-@click.group()
-@click.version_option(message="%(version)s", version=VERSION)
-def main():
-    pass
-
-
-@main.command()
-@click.argument("bucket_name")
-@click.option(
-    "--credentials",
-    default=credentials.find(),
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_new_docs(bucket_name, credentials):
+def verify(credentials):
     if not credentials:
         log.error(
             (
@@ -58,8 +45,60 @@ def build_new_docs(bucket_name, credentials):
             log.error(f"Could not find {cmd} command!")
             return sys.exit(1)
 
+
+@click.group()
+@click.version_option(message="%(version)s", version=VERSION)
+def main():
+    pass
+
+
+@main.command()
+@click.argument("bucket_name")
+@click.option(
+    "--credentials",
+    default=credentials.find(),
+    help="Path to the credentials file to use for Google Cloud Storage.",
+)
+def build_new_docs(bucket_name, credentials):
+    verify(credentials)
+
     try:
         generate.build_new_docs(bucket_name, credentials)
+    except Exception as e:
+        log.error(e)
+        sys.exit(1)
+
+
+@main.command()
+@click.argument("bucket_name")
+@click.option(
+    "--credentials",
+    default=credentials.find(),
+    help="Path to the credentials file to use for Google Cloud Storage.",
+)
+def build_all_docs(bucket_name, credentials):
+    verify(credentials)
+
+    try:
+        generate.build_all_docs(bucket_name, credentials)
+    except Exception as e:
+        log.error(e)
+        sys.exit(1)
+
+
+@main.command()
+@click.argument("bucket_name")
+@click.argument("object_name")
+@click.option(
+    "--credentials",
+    default=credentials.find(),
+    help="Path to the credentials file to use for Google Cloud Storage.",
+)
+def build_one_doc(bucket_name, object_name, credentials):
+    verify(credentials)
+
+    try:
+        generate.build_one_doc(bucket_name, object_name, credentials)
     except Exception as e:
         log.error(e)
         sys.exit(1)

--- a/generate.sh
+++ b/generate.sh
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO:
-# * If FORCE_GENERATE_ALL env var is set to true, regenerate all.
-# * If SOURCE_FILE_NAME is set, force regeneration for that file.
-
 set -e
 
 if [ -z "$SOURCE_BUCKET" ]; then
@@ -28,4 +24,11 @@ fi
 export PATH=$PATH:${HOME}/.local/bin
 
 python3 -m pip install .
-python3 docpipeline/__main__.py build-new-docs $SOURCE_BUCKET
+
+if [ "$FORCE_GENERATE_ALL" == "true" ]; then
+    python3 docpipeline/__main__.py build-all-docs $SOURCE_BUCKET
+elif [ -n "$SOURCE_BLOB" ]; then
+    python3 docpipeline/__main__.py build-one-doc $SOURCE_BUCKET $SOURCE_BLOB
+else
+    python3 docpipeline/__main__.py build-new-docs $SOURCE_BUCKET
+fi

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -97,3 +97,17 @@ def test_generate(yaml_dir, tmpdir):
     assert html_file_path.isfile()
     got_text = html_file_path.read_text("utf-8")
     assert "devsite" in got_text
+
+    # Force regeneration and verify the timestamp is different.
+    html_blob = bucket.get_blob(html_blob_name)
+    t1 = html_blob.updated
+    generate.build_all_docs(test_bucket, credentials)
+    html_blob = bucket.get_blob(html_blob_name)
+    t2 = html_blob.updated
+    assert t1 != t2
+
+    # Force regeneration of a single doc and verify timestamp.
+    generate.build_one_doc(test_bucket, yaml_blob_name, credentials)
+    html_blob = bucket.get_blob(html_blob_name)
+    t3 = html_blob.updated
+    assert t2 != t3


### PR DESCRIPTION
This will make it so if we ever change the HTML style, we can regenerate
all of the docs. Conveniently, the YAML source does not need to change,
only the HTML template.

This is also helpful for one-off cases where you want to regenerate the
HTML for a single package.

In the future, it's possible we would want the ability to regenerate
the docs for a single language. But, we can add that feature as needed.

For env vars, I used `SOURCE_BLOB` instead of the planned
`SOURCE_FILE_NAME` because blobs aren't really files and `SOURCE_BLOB`
goes nicely with `SOURCE_BUCKET`.