### PR TITLE
feat: include .md files

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -29,7 +29,7 @@ DOCFX_JSON_TEMPLATE = """
   "build": {{
     "content": [
       {{
-        "files": "**/*.yml",
+        "files": ["**/*.yml", "**/*.md"],
         "src": "obj/api",
         "dest": "api"
       }}


### PR DESCRIPTION
This adds markdown files to the input for the DocFX generator, which makes it so we can incorporate markdown files from client libraries.

We may need style/formatting changes in the future, but this is a good start.