### PR TITLE
fix: increase build timeout

### DIFF
--- a/ci/common.cfg
+++ b/ci/common.cfg
@@ -14,6 +14,9 @@
 
 # Format: //devtools/kokoro/config/proto/build.proto
 
+# Build timeout set for 10 hours
+timeout_mins: 600
+
 # Use the trampoline script to run in docker.
 build_file: "doc-pipeline/ci/trampoline_v2.sh"
 


### PR DESCRIPTION
When there are a lot to build, the default 3 hours has not been enough

Fixes #41 