### PR TITLE
cleanup: add support for toc.html and toc.yaml

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -120,9 +120,9 @@ def process_blob(blob, credentials, devsite_template):
     # Rename the output TOC file to be _toc.yaml to match the expected
     # format. As well, support both toc.html and toc.yaml
     try:
-        shutil.move(output_path.joinpath("toc.html"), output_path.joinpath("_toc.yaml"))
-    except FileNotFoundError:
         shutil.move(output_path.joinpath("toc.yaml"), output_path.joinpath("_toc.yaml"))
+    except FileNotFoundError:
+        shutil.move(output_path.joinpath("toc.html"), output_path.joinpath("_toc.yaml"))
 
     log.success(f"Done building HTML for {blob.name}. Starting upload...")
 

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -118,8 +118,11 @@ def process_blob(blob, credentials, devsite_template):
     )
 
     # Rename the output TOC file to be _toc.yaml to match the expected
-    # format.
-    shutil.move(output_path.joinpath("toc.html"), output_path.joinpath("_toc.yaml"))
+    # format. As well, support both toc.html and toc.yaml
+    try:
+        shutil.move(output_path.joinpath("toc.html"), output_path.joinpath("_toc.yaml"))
+    except FileNotFoundError:
+        shutil.move(output_path.joinpath("toc.yaml"), output_path.joinpath("_toc.yaml"))
 
     log.success(f"Done building HTML for {blob.name}. Starting upload...")
 


### PR DESCRIPTION
Adding support for both `toc.html` and `toc.yaml`, which seems to only be the case for one file under doc-pipeline.

Fixes #48 