### PR TITLE
feat: adding support for docs.metadata.json

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -136,7 +136,7 @@ def process_blob(blob, credentials, devsite_template):
     # Reuse the same docs.metadata file. The original docfx- prefix is an
     # command line option when uploading, not part of docs.metadata.
     shutil.copyfile(
-        api_path.joinpath(metadata_file), output_path.joinpath(metadata_file)
+        metadata_path, output_path.joinpath(metadata_file)
     )
 
     shell.run(

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -95,7 +95,7 @@ def process_blob(blob, credentials, devsite_template):
 
     metadata_path = api_path.joinpath(metadata_file)
     metadata = metadata_pb2.Metadata()
-    if metadata_file == "docs.metadata.json":
+    if metadata_file.endswith(".json"):
         json_format.Parse(metadata_path.read_text(), metadata)
     else:
         text_format.Merge(metadata_path.read_text(), metadata)

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -135,9 +135,7 @@ def process_blob(blob, credentials, devsite_template):
 
     # Reuse the same docs.metadata file. The original docfx- prefix is an
     # command line option when uploading, not part of docs.metadata.
-    shutil.copyfile(
-        metadata_path, output_path.joinpath(metadata_file)
-    )
+    shutil.copyfile(metadata_path, output_path.joinpath(metadata_file))
 
     shell.run(
         [

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -89,7 +89,11 @@ def process_blob(blob, credentials, devsite_template):
     tar.decompress(tar_filename, api_path)
     log.info(f"Decompressed {blob.name} in {api_path}")
 
-    metadata_path = api_path.joinpath("docs.metadata")
+    metadata_file = "docs.metadata"
+    if api_path.joinpath("docs.metadata.json").exists():
+        metadata_file = "docs.metadata.json"
+
+    metadata_path = api_path.joinpath(metadata_file)
     metadata = metadata_pb2.Metadata()
     text_format.Merge(metadata_path.read_text(), metadata)
     pkg = metadata.name
@@ -129,7 +133,7 @@ def process_blob(blob, credentials, devsite_template):
     # Reuse the same docs.metadata file. The original docfx- prefix is an
     # command line option when uploading, not part of docs.metadata.
     shutil.copyfile(
-        api_path.joinpath("docs.metadata"), output_path.joinpath("docs.metadata")
+        api_path.joinpath(metadata_file), output_path.joinpath(metadata_file)
     )
 
     shell.run(

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -20,7 +20,7 @@ from docuploader import log, shell, tar
 from docuploader.protos import metadata_pb2
 from google.cloud import storage
 from google.oauth2 import service_account
-from google.protobuf import text_format
+from google.protobuf import text_format, json_format
 
 
 DOCFX_PREFIX = "docfx-"
@@ -95,7 +95,10 @@ def process_blob(blob, credentials, devsite_template):
 
     metadata_path = api_path.joinpath(metadata_file)
     metadata = metadata_pb2.Metadata()
-    text_format.Merge(metadata_path.read_text(), metadata)
+    if metadata_file == "docs.metadata.json":
+        json_format.Parse(metadata_path.read_text(), metadata)
+    else:
+        text_format.Merge(metadata_path.read_text(), metadata)
     pkg = metadata.name
 
     with open(tmp_path.joinpath("docfx.json"), "w") as f:


### PR DESCRIPTION
Since building docs.metadata as requested by docuploader can be trickier to work with than building a docs.metadata.json, doc-pipeline will support adding docs.metadata.json.

Fixes internally filed issue