### PR TITLE
fix: accommodate docs.metadata and api directory

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -114,10 +114,10 @@ def process_blob(blob, credentials, devsite_template):
     log.info(f"Decompressed {blob.name} in {decompress_path}")
 
     metadata_file = "docs.metadata"
-    if api_path.joinpath("docs.metadata.json").exists():
+    if decompress_path.joinpath("docs.metadata.json").exists():
         metadata_file = "docs.metadata.json"
 
-    metadata_path = api_path.joinpath(metadata_file)
+    metadata_path = decompress_path.joinpath(metadata_file)
     metadata = metadata_pb2.Metadata()
     if metadata_file.endswith(".json"):
         json_format.Parse(metadata_path.read_text(), metadata)


### PR DESCRIPTION
Currently it does not process when we have a typical case of `docs.metadata*` in the top directory but not in the `api/` directory. Fixing this by always looking for `docs.metadata` in the `decompress_path` as docuploader always requires it in this directory. Using this variable will allow us to not have to search for the file, but simply look in the top directory of the tarball which is noted by `decompress_path`