### PR TITLE
fix: Use obj/examples instead of obj/snippets for samples

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -51,7 +51,7 @@ DOCFX_JSON_TEMPLATE = """
       "_projectPath": "{project_path}"
     }},
     "overwrite": [
-      "obj/snippets/*.md"
+      "obj/examples/*.md"
     ],
     "dest": "site",
     "xref": [{xrefs}],

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -219,7 +219,7 @@ class TestGenerate(unittest.TestCase):
       "_projectPath": "/python/"
     },
     "overwrite": [
-      "obj/snippets/*.md"
+      "obj/examples/*.md"
     ],
     "dest": "site",
     "xref": ["one.yml", "two.yml"],


### PR DESCRIPTION
("Examples" is the name used in the templates, so I'm trying to be consistent.)