### PR TITLE
fix: create xrefmap directories when downloading

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -220,9 +220,10 @@ def download_xrefs(client, bucket):
     xrefs_dir.mkdir(parents=True, exist_ok=True)
     xrefs = []
     for xref_blob in client.list_blobs(bucket, prefix=XREFS_DIR_NAME):
-        xref_path = str(pathlib.Path(xref_blob.name).absolute())
+        xref_path = pathlib.Path(xref_blob.name).absolute()
+        xref_path.parents[0].mkdir(parents=True, exist_ok=True)
         xref_blob.download_to_filename(xref_path)
-        xrefs.append(xref_path)
+        xrefs.append(str(xref_path))
     log.info(f"Downloaded the xref files to {xrefs_dir.absolute()}")
     return xrefs, xrefs_dir
 

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -221,7 +221,7 @@ def download_xrefs(client, bucket):
     xrefs = []
     for xref_blob in client.list_blobs(bucket, prefix=XREFS_DIR_NAME):
         xref_path = pathlib.Path(xref_blob.name).absolute()
-        xref_path.parents[0].mkdir(parents=True, exist_ok=True)
+        xref_path.parent.mkdir(parents=True, exist_ok=True)
         xref_blob.download_to_filename(xref_path)
         xrefs.append(str(xref_path))
     log.info(f"Downloaded the xref files to {xrefs_dir.absolute()}")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -206,7 +206,9 @@ def test_generate(yaml_dir, tmpdir):
     xrefs, xref_dir = generate.download_xrefs(storage_client, test_bucket)
     assert len(xrefs) == 1
     assert xrefs[0].endswith("python-doc-pipeline-test-2.1.1.tar.gz.yml")
+    assert pathlib.Path(xrefs[0]).exists()
     assert xref_dir.name == generate.XREFS_DIR_NAME
+    shutil.rmtree(xref_dir)
 
     # Force regeneration and verify the timestamp is different.
     html_blob = bucket.get_blob(html_blob.name)
@@ -235,6 +237,26 @@ def test_generate(yaml_dir, tmpdir):
     html_blob = bucket.get_blob(html_blob.name)
     t5 = html_blob.updated
     assert t4 == t5
+
+
+def test_download_xrefs():
+    test_file = generate.XREFS_DIR_NAME + "/test/xrefmap.yml"
+    test_bucket, credentials, storage_client = test_init()
+    bucket = storage_client.get_bucket(test_bucket)
+    test_blob = bucket.blob(test_file)
+    if test_blob.exists():
+        test_blob.delete()
+    test_blob.upload_from_string("unused")
+
+    xrefs, xref_dir = generate.download_xrefs(storage_client, test_bucket)
+
+    test_blob.delete()
+
+    downloaded_file = xref_dir.joinpath("test/xrefmap.yml")
+    assert downloaded_file.exists()
+    assert len(xrefs) > 0
+
+    shutil.rmtree(xref_dir)
 
 
 def test_add_prettyprint():


### PR DESCRIPTION
Otherwise, download_to_filename throws an error when the name includes a
/.

Fixes #68.