### PR TITLE
feat: one line command to convert YAMLs to HTML

### DIFF
--- a/.trampolinerc
+++ b/.trampolinerc
@@ -23,6 +23,7 @@ pass_down_envvars+=(
     "FORCE_GENERATE_ALL" # Set to force regeneration of all blobs.
     "TEST_BUCKET"        # Must set when running tests.
     "LANGUAGE"           # For specifying specific language builds.
+    "INPUT"              # For specifying local input source.
 )
 
 # Prevent unintentional override on the default image.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ black docpipeline tests
 ### Running locally for one package
 
 1. Create a directory inside `doc-pipeline` (for example, `my-dir`).
-1. Move the files necessary to build for one pacakage over to `my-dir`.
+1. Create a `docs.metadata` file in `my-dir`. You can copy one from [here](https://github.com/googleapis/doc-pipeline/blob/master/testdata/docs.metadata).
+1. Move or copy the `.yml` files for one package to `my-dir`.
 1. Run the following command, replacing `my-dir` with your directory name:
    ```
    INPUT=my-dir TRAMPOLINE_BUILD_FILE=./generate.sh TRAMPOLINE_IMAGE=gcr.io/cloud-devrel-kokoro-resources/docfx TRAMPOLINE_DOCKERFILE=docfx/Dockerfile ci/trampoline_v2.sh

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ black docpipeline tests
 1. The script runs `docfx build` over the package in my-dir, and places the
    resulting HTML inside a subdirectory in `my-dir`. The subdirectory is
    named after the package name found in the metadata.
-1. Note: running through this method will skip on processing xrefs other than
-   the ones found in the metadata.
+1. Note: running through this method will skip on processing xrefs.
 
 ### Running locally with Cloud Storage bucket
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,21 @@ black docpipeline tests
 1. The tests upload a test DocFX YAML tarball, call the generator, and verify
    the content.
 
-### Running locally
+### Running locally for one package
+
+1. Create a directory on doc-pipeline (`my-dir`).
+1. Move the files necessary to build for one pacakage over to `my-dir`.
+1. Run the following command, replacing `my-dir` with your directory name:
+   ```
+   INPUT=my-dir TRAMPOLINE_BUILD_FILE=./generate.sh TRAMPOLINE_IMAGE=gcr.io/cloud-devrel-kokoro-resources/docfx TRAMPOLINE_DOCKERFILE=docfx/Dockerfile ci/trampoline_v2.sh
+   ```
+1. The script runs `docfx build` over the package in my-dir, and places the
+   resulting HTML inside a subdirectory in `my-dir`. The subdirectory is
+   named after the package name found in the metadata.
+1. Note: running through this method will skip on processing xrefs other than
+   the ones found in the metadata.
+
+### Running locally with Cloud Storage bucket
 
 1. Create a Cloud Storage bucket and add a `docfx-*.tgz` file. For example:
    ```

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ black docpipeline tests
 
 ### Running locally for one package
 
-1. Create a directory on doc-pipeline (`my-dir`).
+1. Create a directory inside `doc-pipeline` (for example, `my-dir`).
 1. Move the files necessary to build for one pacakage over to `my-dir`.
 1. Run the following command, replacing `my-dir` with your directory name:
    ```

--- a/docpipeline/__main__.py
+++ b/docpipeline/__main__.py
@@ -19,7 +19,7 @@ import sys
 import click
 from docuploader import credentials, log
 
-from docpipeline import generate
+from docpipeline import generate, local_generate
 
 
 # The docuploader logger is initialized as "docuploader"; change it to docpipeline.
@@ -117,6 +117,16 @@ def build_language_docs(bucket_name, language, credentials):
 
     try:
         generate.build_language_docs(bucket_name, language, credentials)
+    except Exception as e:
+        log.error(e)
+        sys.exit(1)
+
+
+@main.command()
+@click.argument("input_path")
+def build_local_doc(input_path):
+    try:
+        local_generate.build_local_doc(input_path)
     except Exception as e:
         log.error(e)
         sys.exit(1)

--- a/docpipeline/local_generate.py
+++ b/docpipeline/local_generate.py
@@ -19,6 +19,23 @@ from docuploader import log
 from docpipeline import generate
 
 
+def process_local_blob(blob, devsite_template):
+    is_bucket = False
+    tmp_path, metadata, site_path = generate.build_and_format(
+        blob, is_bucket, devsite_template
+    )
+
+    # For local generation
+    output_path = blob.joinpath(metadata.name)
+    if output_path.exists():
+        log.info(f"deleting existing directory: {output_path}")
+        shutil.rmtree(output_path)
+    shutil.copytree(site_path, output_path, dirs_exist_ok=True)
+    shutil.rmtree(tmp_path)
+
+    log.success(f"Done with {metadata.name}!")
+
+
 def build_local_doc(input_path):
     log.info("Building docs locally...")
     log.info("Let's build some docs!")
@@ -30,6 +47,6 @@ def build_local_doc(input_path):
     if not input_path.exists():
         raise Exception(f"{input_path} is not a valid directory path!")
 
-    generate.process_blob(input_path, "", devsite_template)
+    process_local_blob(input_path, devsite_template)
 
     shutil.rmtree(templates_dir)

--- a/docpipeline/local_generate.py
+++ b/docpipeline/local_generate.py
@@ -14,197 +14,22 @@
 
 import pathlib
 import shutil
-import tempfile
 
-from docuploader import log, shell
-from docuploader.protos import metadata_pb2
-from google.protobuf import text_format, json_format
-
-
-DOCFX_PREFIX = "docfx-"
-
-DOCFX_JSON_TEMPLATE = """
-{{
-  "build": {{
-    "content": [
-      {{
-        "files": ["**/*.yml", "**/*.md"],
-        "src": "obj/api"
-      }}
-    ],
-    "globalMetadata": {{
-      "_appTitle": "{package}",
-      "_disableContribution": true,
-      "_appFooter": " ",
-      "_disableNavbar": true,
-      "_disableBreadcrumb": true,
-      "_enableSearch": false,
-      "_disableToc": true,
-      "_disableSideFilter": true,
-      "_disableAffix": true,
-      "_disableFooter": true,
-      "_rootPath": "{path}",
-      "_projectPath": "{project_path}"
-    }},
-    "overwrite": [
-      "obj/examples/*.md"
-    ],
-    "dest": "site",
-    "xref": [{xrefs}],
-    "xrefService": [{xref_services}],
-  }}
-}}
-"""
-
-
-def clone_templates(dir):
-    shell.run(
-        [
-            "git",
-            "clone",
-            "--depth=1",
-            "https://github.com/googleapis/doc-templates.git",
-            ".",
-        ],
-        cwd=dir,
-        hide_output=True,
-    )
-
-
-def format_docfx_json(metadata):
-    pkg = metadata.name
-    xrefs = ", ".join([f'"{xref}"' for xref in metadata.xrefs])
-    xref_services = ", ".join([f'"{xref}"' for xref in metadata.xref_services])
-
-    return DOCFX_JSON_TEMPLATE.format(
-        package=pkg,
-        path=f"/{metadata.language}/docs/reference/{pkg}/latest",
-        project_path=f"/{metadata.language}/",
-        xrefs=xrefs,
-        xref_services=xref_services,
-    )
-
-
-def add_prettyprint(output_path):
-    files = output_path.glob("**/*.html")
-    # Handle files in binary to avoid line endings
-    # being changed when running on Windows.
-    for file in files:
-        with open(file, "rb") as file_handle:
-            html = file_handle.read()
-        html = html.replace(
-            '<code class="lang-'.encode(), '<code class="prettyprint lang-'.encode()
-        )
-        with open(file, "wb") as file_handle:
-            file_handle.write(html)
-
-
-def setup_docfx(tmp_path, input_path):
-    api_path = decompress_path = tmp_path.joinpath("obj/api")
-
-    api_path.mkdir(parents=True, exist_ok=True)
-
-    for item in input_path.iterdir():
-        if item.is_dir() and item.name == "api":
-            decompress_path = tmp_path.joinpath("obj")
-            break
-
-    shutil.copytree(input_path, decompress_path, dirs_exist_ok=True)
-    log.info(f"Decompressed in {decompress_path}")
-
-    metadata = metadata_pb2.Metadata()
-    metadata_path = decompress_path.joinpath("docs.metadata.json")
-    if metadata_path.exists():
-        json_format.Parse(metadata_path.read_text(), metadata)
-    else:
-        metadata_path = decompress_path.joinpath("docs.metadata")
-        text_format.Merge(metadata_path.read_text(), metadata)
-
-    with open(tmp_path.joinpath("docfx.json"), "w") as f:
-        f.write(format_docfx_json(metadata))
-    log.info("Wrote docfx.json")
-
-    # TODO: remove this once _toc.yaml is no longer created.
-    if pathlib.Path(api_path.joinpath("_toc.yaml")).is_file():
-        shutil.move(api_path.joinpath("_toc.yaml"), api_path.joinpath("toc.yml"))
-
-    return metadata_path, metadata
-
-
-def process_blob(input_path, devsite_template):
-    tmp_path = pathlib.Path(tempfile.TemporaryDirectory(prefix="doc-pipeline.").name)
-
-    metadata_path, metadata = setup_docfx(tmp_path, input_path)
-
-    site_path = tmp_path.joinpath("site")
-
-    log.info(f"Running `docfx build` for {metadata.name}...")
-    shell.run(
-        ["docfx", "build", "-t", f"{devsite_template.absolute()}"],
-        cwd=tmp_path,
-        hide_output=False,
-    )
-
-    # Rename the output TOC file to be _toc.yaml to match the expected
-    # format. As well, support both toc.html and toc.yaml
-    try:
-        shutil.move(site_path.joinpath("toc.yaml"), site_path.joinpath("_toc.yaml"))
-    except FileNotFoundError:
-        shutil.move(site_path.joinpath("toc.html"), site_path.joinpath("_toc.yaml"))
-
-    # Remove the manifest.json file.
-    site_path.joinpath("manifest.json").unlink()
-
-    # Add the prettyprint class to code snippets
-    add_prettyprint(site_path)
-
-    log.success(f"Done building HTML for {metadata.name}. Copying over...")
-
-    # Reuse the same docs.metadata file. The original docfx- prefix is an
-    # command line option when uploading, not part of docs.metadata.
-    shutil.copy(metadata_path, site_path)
-
-    output_path = input_path.joinpath(metadata.name)
-    if output_path.exists():
-        log.info(f"deleting existing directory: {output_path}")
-        shutil.rmtree(output_path)
-    shutil.copytree(site_path, output_path, dirs_exist_ok=True)
-    shutil.rmtree(tmp_path)
-
-    log.success(f"Done with {metadata.name}!")
-
-
-def build_blob(input_path):
-    log.info("Let's build some docs!")
-
-    # Clone doc-templates.
-    templates_dir = pathlib.Path("doc-templates")
-    if templates_dir.is_dir():
-        shutil.rmtree(templates_dir)
-    templates_dir.mkdir(parents=True, exist_ok=True)
-    log.info(f"Cloning templates into {templates_dir.absolute()}")
-    clone_templates(templates_dir)
-    log.info(f"Got the templates ({templates_dir.absolute()})!")
-    devsite_template = templates_dir.joinpath("third_party/docfx/templates/devsite")
-
-    failure = 0
-    try:
-        log.info("Processing files in directory...")
-        process_blob(input_path, devsite_template)
-    except Exception as e:
-        failure = 1
-        log.error(f"Error processing local build, {e}")
-
-    shutil.rmtree(templates_dir)
-
-    if failure:
-        raise Exception("Got errors while processing the directory")
-
-    log.success("Done!")
+from docuploader import log
+from docpipeline import generate
 
 
 def build_local_doc(input_path):
+    log.info("Building docs locally...")
+    log.info("Let's build some docs!")
+
+    # Clone doc-templates
+    templates_dir, devsite_template = generate.setup_templates()
+
     input_path = pathlib.Path(input_path)
     if not input_path.exists():
         raise Exception(f"{input_path} is not a valid directory path!")
-    build_blob(input_path)
+
+    generate.process_blob(input_path, "", devsite_template)
+
+    shutil.rmtree(templates_dir)

--- a/docpipeline/local_generate.py
+++ b/docpipeline/local_generate.py
@@ -1,0 +1,213 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import shutil
+import tempfile
+import tarfile
+
+from docuploader import log, shell, tar
+from docuploader.protos import metadata_pb2
+from google.cloud import storage
+from google.oauth2 import service_account
+from google.protobuf import text_format, json_format
+
+
+DOCFX_PREFIX = "docfx-"
+
+DOCFX_JSON_TEMPLATE = """
+{{
+  "build": {{
+    "content": [
+      {{
+        "files": ["**/*.yml", "**/*.md"],
+        "src": "obj/api"
+      }}
+    ],
+    "globalMetadata": {{
+      "_appTitle": "{package}",
+      "_disableContribution": true,
+      "_appFooter": " ",
+      "_disableNavbar": true,
+      "_disableBreadcrumb": true,
+      "_enableSearch": false,
+      "_disableToc": true,
+      "_disableSideFilter": true,
+      "_disableAffix": true,
+      "_disableFooter": true,
+      "_rootPath": "{path}",
+      "_projectPath": "{project_path}"
+    }},
+    "overwrite": [
+      "obj/examples/*.md"
+    ],
+    "dest": "site",
+    "xref": [{xrefs}],
+    "xrefService": [{xref_services}],
+  }}
+}}
+"""
+
+
+def clone_templates(dir):
+    shell.run(
+        [
+            "git",
+            "clone",
+            "--depth=1",
+            "https://github.com/googleapis/doc-templates.git",
+            ".",
+        ],
+        cwd=dir,
+        hide_output=True,
+    )
+
+
+def format_docfx_json(metadata):
+    pkg = metadata.name
+    xrefs = ", ".join([f'"{xref}"' for xref in metadata.xrefs])
+    xref_services = ", ".join([f'"{xref}"' for xref in metadata.xref_services])
+
+    return DOCFX_JSON_TEMPLATE.format(
+        package=pkg,
+        path=f"/{metadata.language}/docs/reference/{pkg}/latest",
+        project_path=f"/{metadata.language}/",
+        xrefs=xrefs,
+        xref_services=xref_services,
+    )
+
+
+def add_prettyprint(output_path):
+    files = output_path.glob("**/*.html")
+    # Handle files in binary to avoid line endings
+    # being changed when running on Windows.
+    for file in files:
+        with open(file, "rb") as file_handle:
+            html = file_handle.read()
+        html = html.replace(
+            '<code class="lang-'.encode(), '<code class="prettyprint lang-'.encode()
+        )
+        with open(file, "wb") as file_handle:
+            file_handle.write(html)
+
+
+def setup_docfx(tmp_path, input_path):
+    api_path = decompress_path = tmp_path.joinpath("obj/api")
+
+    api_path.mkdir(parents=True, exist_ok=True)
+
+    for item in input_path.iterdir():
+        if item.is_dir() and item.name == "api":
+            decompress_path = tmp_path.joinpath("obj")
+            break
+
+    shutil.copytree(input_path, decompress_path, dirs_exist_ok=True)
+    log.info(f"Decompressed in {decompress_path}")
+
+    metadata = metadata_pb2.Metadata()
+    metadata_path = decompress_path.joinpath("docs.metadata.json")
+    if metadata_path.exists():
+        json_format.Parse(metadata_path.read_text(), metadata)
+    else:
+        metadata_path = decompress_path.joinpath("docs.metadata")
+        text_format.Merge(metadata_path.read_text(), metadata)
+
+    with open(tmp_path.joinpath("docfx.json"), "w") as f:
+        f.write(format_docfx_json(metadata))
+    log.info("Wrote docfx.json")
+
+    # TODO: remove this once _toc.yaml is no longer created.
+    if pathlib.Path(api_path.joinpath("_toc.yaml")).is_file():
+        shutil.move(api_path.joinpath("_toc.yaml"), api_path.joinpath("toc.yml"))
+
+    return metadata_path, metadata
+
+
+def process_blob(input_path, devsite_template):
+    tmp_path = pathlib.Path(tempfile.TemporaryDirectory(prefix="doc-pipeline.").name)
+
+    metadata_path, metadata = setup_docfx(tmp_path, input_path)
+
+    site_path = tmp_path.joinpath("site")
+
+    log.info(f"Running `docfx build` for {metadata.name}...")
+    shell.run(
+        ["docfx", "build", "-t", f"{devsite_template.absolute()}"],
+        cwd=tmp_path,
+        hide_output=False,
+    )
+
+    # Rename the output TOC file to be _toc.yaml to match the expected
+    # format. As well, support both toc.html and toc.yaml
+    try:
+        shutil.move(site_path.joinpath("toc.yaml"), site_path.joinpath("_toc.yaml"))
+    except FileNotFoundError:
+        shutil.move(site_path.joinpath("toc.html"), site_path.joinpath("_toc.yaml"))
+
+    # Remove the manifest.json file.
+    site_path.joinpath("manifest.json").unlink()
+
+    # Add the prettyprint class to code snippets
+    add_prettyprint(site_path)
+
+    log.success(f"Done building HTML for {metadata.name}. Copying over...")
+
+    # Reuse the same docs.metadata file. The original docfx- prefix is an
+    # command line option when uploading, not part of docs.metadata.
+    shutil.copy(metadata_path, site_path)
+
+    output_path = input_path.joinpath(metadata.name)
+    if output_path.exists():
+        log.info(f"deleting existing directory: {output_path}")
+        shutil.rmtree(output_path)
+    shutil.copytree(site_path, output_path, dirs_exist_ok=True)
+    shutil.rmtree(tmp_path)
+
+    log.success(f"Done with {metadata.name}!")
+
+
+def build_blob(input_path):
+    log.info("Let's build some docs!")
+
+    # Clone doc-templates.
+    templates_dir = pathlib.Path("doc-templates")
+    if templates_dir.is_dir():
+        shutil.rmtree(templates_dir)
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    log.info(f"Cloning templates into {templates_dir.absolute()}")
+    clone_templates(templates_dir)
+    log.info(f"Got the templates ({templates_dir.absolute()})!")
+    devsite_template = templates_dir.joinpath("third_party/docfx/templates/devsite")
+
+    failure = 0
+    try:
+        log.info("Processing files in directory...")
+        process_blob(input_path, devsite_template)
+    except Exception as e:
+        failure = 1
+        log.error(f"Error processing local build, {e}")
+
+    shutil.rmtree(templates_dir)
+
+    if failure:
+        raise Exception("Got errors while processing the directory")
+
+    log.success("Done!")
+
+
+def build_local_doc(input_path):
+    input_path = pathlib.Path(input_path)
+    if not input_path.exists():
+        raise Exception(f"{input_path} is not a valid directory path!")
+    build_blob(input_path)

--- a/docpipeline/local_generate.py
+++ b/docpipeline/local_generate.py
@@ -15,12 +15,9 @@
 import pathlib
 import shutil
 import tempfile
-import tarfile
 
-from docuploader import log, shell, tar
+from docuploader import log, shell
 from docuploader.protos import metadata_pb2
-from google.cloud import storage
-from google.oauth2 import service_account
 from google.protobuf import text_format, json_format
 
 

--- a/generate.sh
+++ b/generate.sh
@@ -22,19 +22,20 @@ python3 -m pip install .
 
 if [ -n "$INPUT" ]; then
   python3 docpipeline/__main__.py build-local-doc $INPUT
-else
-  if [ -z "$SOURCE_BUCKET" ]; then
-      echo "Must set SOURCE_BUCKET"
-      exit 1
-  fi
+  exit
+fi
 
-  if [ "$FORCE_GENERATE_ALL" == "true" ]; then
-      python3 docpipeline/__main__.py build-all-docs $SOURCE_BUCKET
-  elif [ -n "$LANGUAGE" ]; then
-      python3 docpipeline/__main__.py build-language-docs $SOURCE_BUCKET $LANGUAGE
-  elif [ -n "$SOURCE_BLOB" ]; then
-      python3 docpipeline/__main__.py build-one-doc $SOURCE_BUCKET $SOURCE_BLOB
-  else
-      python3 docpipeline/__main__.py build-new-docs $SOURCE_BUCKET
-  fi
+if [ -z "$SOURCE_BUCKET" ]; then
+  echo "Must set SOURCE_BUCKET"
+  exit 1
+fi
+
+if [ "$FORCE_GENERATE_ALL" == "true" ]; then
+    python3 docpipeline/__main__.py build-all-docs $SOURCE_BUCKET
+elif [ -n "$LANGUAGE" ]; then
+    python3 docpipeline/__main__.py build-language-docs $SOURCE_BUCKET $LANGUAGE
+elif [ -n "$SOURCE_BLOB" ]; then
+    python3 docpipeline/__main__.py build-one-doc $SOURCE_BUCKET $SOURCE_BLOB
+else
+    python3 docpipeline/__main__.py build-new-docs $SOURCE_BUCKET
 fi

--- a/generate.sh
+++ b/generate.sh
@@ -15,22 +15,26 @@
 
 set -e
 
-if [ -z "$SOURCE_BUCKET" ]; then
-    echo "Must set SOURCE_BUCKET"
-    exit 1
-fi
-
 # Add the path where docuploader gets installed to PATH.
 export PATH=$PATH:${HOME}/.local/bin
 
 python3 -m pip install .
 
-if [ "$FORCE_GENERATE_ALL" == "true" ]; then
-    python3 docpipeline/__main__.py build-all-docs $SOURCE_BUCKET
-elif [ -n "$LANGUAGE" ]; then
-    python3 docpipeline/__main__.py build-language-docs $SOURCE_BUCKET $LANGUAGE
-elif [ -n "$SOURCE_BLOB" ]; then
-    python3 docpipeline/__main__.py build-one-doc $SOURCE_BUCKET $SOURCE_BLOB
+if [ -n "$INPUT" ]; then
+  python3 docpipeline/__main__.py build-local-doc $INPUT
 else
-    python3 docpipeline/__main__.py build-new-docs $SOURCE_BUCKET
+  if [ -z "$SOURCE_BUCKET" ]; then
+      echo "Must set SOURCE_BUCKET"
+      exit 1
+  fi
+
+  if [ "$FORCE_GENERATE_ALL" == "true" ]; then
+      python3 docpipeline/__main__.py build-all-docs $SOURCE_BUCKET
+  elif [ -n "$LANGUAGE" ]; then
+      python3 docpipeline/__main__.py build-language-docs $SOURCE_BUCKET $LANGUAGE
+  elif [ -n "$SOURCE_BLOB" ]; then
+      python3 docpipeline/__main__.py build-one-doc $SOURCE_BUCKET $SOURCE_BLOB
+  else
+      python3 docpipeline/__main__.py build-new-docs $SOURCE_BUCKET
+  fi
 fi

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -24,7 +24,7 @@ from google.cloud import storage
 from google.oauth2 import service_account
 import pytest
 
-from docpipeline import generate
+from docpipeline import generate, local_generate
 
 
 @pytest.fixture
@@ -117,13 +117,24 @@ def run_generate(storage_client, credentials, test_bucket):
     assert len(blobs) == len(start_blobs) + 2
 
 
-# Simple verification of the content
-def verify_content(html_blob, tmpdir):
-    assert html_blob.exists()
+def run_local_generate(local_path):
+    # Generate!
+    try:
+        local_generate.build_local_doc(local_path)
+    except Exception as e:
+        pytest.fail(f"build_local_doc raised an exception: {e}")
 
-    tar_path = tmpdir.join("out.tgz")
-    html_blob.download_to_filename(tar_path)
-    tar.decompress(tar_path, tmpdir)
+    # Verify the results.
+    # Expect a local directory of pages to be made from building locally
+    output_path = local_path.join("doc-pipeline-test")
+    assert output_path.isdir()
+
+    # Return the directory containing locally generated docs
+    return output_path
+
+
+def verify_template_content(tmpdir):
+
     assert tmpdir.join("docs.metadata").isfile()
 
     # Check _rootPath and docs.metadata parsing worked.
@@ -132,14 +143,6 @@ def verify_content(html_blob, tmpdir):
     got_text = toc_file_path.read_text("utf-8")
     # See testdata/docs.metadata.
     assert "/python/docs/reference/doc-pipeline-test/latest" in got_text
-
-    # Check xrefmap.yml was created.
-    xref_path = tmpdir.join("xrefmap.yml")
-    assert xref_path.isfile()
-    got_text = xref_path.read_text("utf-8")
-    assert got_text.startswith(
-        "### YamlMime:XRefMap\nbaseUrl: https://cloud.google.com"
-    )
 
     # Check the template worked.
     html_file_path = tmpdir.join("google.api.customhttppattern.html")
@@ -151,6 +154,25 @@ def verify_content(html_blob, tmpdir):
     # Check the manifest.json was not included.
     manifest_path = tmpdir.join("manifest.json")
     assert not manifest_path.exists(), "manifest.json should not be included"
+
+
+# Simple verification of the content
+def verify_content(html_blob, tmpdir):
+    assert html_blob.exists()
+
+    tar_path = tmpdir.join("out.tgz")
+    html_blob.download_to_filename(tar_path)
+    tar.decompress(tar_path, tmpdir)
+
+    verify_template_content(tmpdir)
+
+    # Check xrefmap.yml was created.
+    xref_path = tmpdir.join("xrefmap.yml")
+    assert xref_path.isfile()
+    got_text = xref_path.read_text("utf-8")
+    assert got_text.startswith(
+        "### YamlMime:XRefMap\nbaseUrl: https://cloud.google.com"
+    )
 
 
 def test_apidir(api_dir, tmpdir):
@@ -233,6 +255,13 @@ def test_generate(yaml_dir, tmpdir):
     html_blob = bucket.get_blob(html_blob.name)
     t5 = html_blob.updated
     assert t4 == t5
+
+
+def test_local_generate(yaml_dir, tmpdir):
+    # Test for local generation content
+    output_path = run_local_generate(yaml_dir)
+
+    verify_template_content(output_path)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -118,6 +118,15 @@ def run_generate(storage_client, credentials, test_bucket):
 
 
 def run_local_generate(local_path):
+
+    # Test with invalid path given, must throw exception
+    try:
+        local_generate.build_local_doc(local_path.basename[1:])
+    except Exception:
+        pass
+    else:
+        pytest.fail("build_local_doc is attempting to generate on invalid input path")
+
     # Generate!
     try:
         local_generate.build_local_doc(local_path)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -205,7 +205,14 @@ def test_setup_docfx(yaml_dir):
     )
 
     tmp_path = pathlib.Path(tempfile.TemporaryDirectory(prefix="doc-pipeline.").name)
-    metadata_path, metadata = generate.setup_docfx(tmp_path, yaml_blob)
+
+    api_path = decompress_path = tmp_path.joinpath("obj/api")
+
+    api_path.mkdir(parents=True, exist_ok=True)
+
+    metadata_path, metadata = generate.setup_bucket_docfx(
+        tmp_path, api_path, decompress_path, yaml_blob
+    )
 
     docfx_json_file = tmp_path.joinpath("docfx.json")
     assert docfx_json_file.exists()


### PR DESCRIPTION
This features will allow a folder of just YAMLs to be quickly converted to HTMLs without interacting with Cloud Storage buckets, and will be done entirely on your local machine. Good for quickly testing to see if the YAML generates correct HTML.

To use this method, create a directory in doc-pipeline containing the YAMLs, like how they would show up before they are tar'd up and sent to Cloud Storage buckets. If we call that directory "docs_test" then from doc-pipeline, run
```INPUT=docs_test TRAMPOLINE_BUILD_FILE=./generate.sh TRAMPOLINE_IMAGE=gcr.io/cloud-devrel-kokoro-resources/docfx TRAMPOLINE_DOCKERFILE=docfx/Dockerfile ci/trampoline_v2.sh```
which would take the contents of `docs_test` directory, build the HTML pages, and return the directory of HTMLs. 

Visually, it would look something like this for the above example:

```
/doc-pipeline
...
|-- docs_test
|    |-- docs.metadata
|    |-- *.yml
```
builds to

```
/doc-pipeline
|-- docs_test
|    |-- docs.metadata
|    |-- *.yml
|    |-- pubsub
|    |    |-- *.html
|    |    |-- _toc.yaml
```
where pubsub would be the metadata name. 

It currently also works with `docs.metadata.json` and even if `docs_test` were to contain directories (api, example) and not have YAML files laid out flat.

Fixes #53