### PR TITLE
feat: download xrefs as needed and support devsite:// xrefs

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -237,8 +237,8 @@ def get_xref(xref, bucket, dir):
             # Be sure to trim the suffix extension.
             version = blob.name[len(prefix) : -len(".tar.gz.yml")]
             # Skip if version doesn't look like a version, like when some other package
-            # name has this one as a prefix (""...foo" and "...foo-beta1").
-            if version[0].isnumeric():
+            # has prefix as a prefix (""...foo-1.0.0" and "...foo-beta1-1.0.0").
+            if version[0].isnumeric() or (version[0] == "v" and version[1].isnumeric()):
                 versions.append(version)
         if len(versions) == 0:
             # There are no versions, so there is no latest version.

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -236,10 +236,13 @@ def get_xref(xref, bucket, dir):
         for blob in blobs:
             # Be sure to trim the suffix extension.
             version = blob.name[len(prefix) : -len(".tar.gz.yml")]
-            # Skip if version doesn't look like a version, like when some other package
-            # has prefix as a prefix (""...foo-1.0.0" and "...foo-beta1-1.0.0").
-            if version[0].isnumeric() or (version[0] == "v" and version[1].isnumeric()):
+            # Skip if version is not a valid version, like when some other package
+            # has prefix as a prefix (...foo-1.0.0" and "...foo-beta1-1.0.0").
+            try:
+                version_sort(version)
                 versions.append(version)
+            except ValueError:
+                pass  # Ignore.
         if len(versions) == 0:
             # There are no versions, so there is no latest version.
             log.error(f"Could not find {xref} in gs://{bucket.name}. Skipping.")

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ dependencies = [
     "click",
     "google-cloud-storage<2.0.0dev",
     "gcp-docuploader",
+    "semver",
 ]
 
 packages = setuptools.find_packages()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -251,6 +251,7 @@ def xref_test_blobs():
         "xrefs/dotnet-my-pkg-v1.1.0.tar.gz.yml",
         "xrefs/dotnet-my-pkg-2.0.0-SNAPSHOT.tar.gz.yml",
         "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml",
+        "xrefs/dotnet-my-pkg-unused-3.0.0.tar.gz.yml",
     ]
     for b in blobs_to_create:
         blob = bucket.blob(b)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -252,6 +252,8 @@ def xref_test_blobs():
         "xrefs/dotnet-my-pkg-2.0.0-SNAPSHOT.tar.gz.yml",
         "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml",
         "xrefs/dotnet-my-pkg-unused-3.0.0.tar.gz.yml",
+        "xrefs/dotnet-v-pkg-v3.0.0.tar.gz.yml",
+        "xrefs/dotnet-v-pkg-v4.0.0.tar.gz.yml",
     ]
     for b in blobs_to_create:
         blob = bucket.blob(b)
@@ -268,6 +270,7 @@ def xref_test_blobs():
         ("devsite://dotnet/my-pkg@1.0.0", "xrefs/dotnet-my-pkg-1.0.0.tar.gz.yml"),
         ("devsite://dotnet/my-pkg", "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml"),
         ("devsite://dotnet/my-pkg@latest", "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml"),
+        ("devsite://dotnet/v-pkg@latest", "xrefs/dotnet-v-pkg-v4.0.0.tar.gz.yml"),
     ],
 )
 def test_get_xref(test_input, expected, tmpdir, xref_test_blobs):

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -173,17 +173,14 @@ def test_setup_docfx(yaml_dir):
         yaml_dir, storage_client, credentials, test_bucket
     )
 
-    xrefs = ["xrefs/test.yml"]
-
     tmp_path = pathlib.Path(tempfile.TemporaryDirectory(prefix="doc-pipeline.").name)
-    metadata_path, metadata = generate.setup_docfx(tmp_path, yaml_blob, xrefs)
+    metadata_path, metadata = generate.setup_docfx(tmp_path, yaml_blob)
 
     docfx_json_file = tmp_path.joinpath("docfx.json")
     assert docfx_json_file.exists()
     with open(docfx_json_file) as w:
         got_text = w.read()
         assert "/python/docs/reference/doc-pipeline-test/latest" in got_text
-        assert xrefs[0] in got_text
 
     assert metadata_path.exists()
     assert metadata.name == "doc-pipeline-test"
@@ -203,12 +200,11 @@ def test_generate(yaml_dir, tmpdir):
 
     # Ensure xref file was properly uploaded. Also ensure download_xrefs gets
     # the right content.
-    xrefs, xref_dir = generate.download_xrefs(storage_client, test_bucket)
-    assert len(xrefs) == 1
-    assert xrefs[0].endswith("python-doc-pipeline-test-2.1.1.tar.gz.yml")
-    assert pathlib.Path(xrefs[0]).exists()
-    assert xref_dir.name == generate.XREFS_DIR_NAME
-    shutil.rmtree(xref_dir)
+    path = generate.get_xref(
+        "devsite://python/doc-pipeline-test", bucket, pathlib.Path(tmpdir)
+    )
+    assert path != ""
+    assert pathlib.Path(path).exists()
 
     # Force regeneration and verify the timestamp is different.
     html_blob = bucket.get_blob(html_blob.name)
@@ -239,24 +235,56 @@ def test_generate(yaml_dir, tmpdir):
     assert t4 == t5
 
 
-def test_download_xrefs():
-    test_file = generate.XREFS_DIR_NAME + "/test/xrefmap.yml"
+@pytest.fixture(scope="module")
+def xref_test_blobs():
     test_bucket, credentials, storage_client = test_init()
     bucket = storage_client.get_bucket(test_bucket)
-    test_blob = bucket.blob(test_file)
-    if test_blob.exists():
-        test_blob.delete()
-    test_blob.upload_from_string("unused")
 
-    xrefs, xref_dir = generate.download_xrefs(storage_client, test_bucket)
+    # Remove all existing test xref blobs.
+    blobs_to_delete = bucket.list_blobs(prefix="xrefs/")
+    for blob in blobs_to_delete:
+        blob.delete()
 
-    test_blob.delete()
+    blobs_to_create = [
+        "xrefs/go-unused-v0.0.1.tar.gz.yml",
+        "xrefs/dotnet-my-pkg-1.0.0.tar.gz.yml",
+        "xrefs/dotnet-my-pkg-v1.1.0.tar.gz.yml",
+        "xrefs/dotnet-my-pkg-2.0.0-SNAPSHOT.tar.gz.yml",
+        "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml",
+    ]
+    for b in blobs_to_create:
+        blob = bucket.blob(b)
+        if not blob.exists():
+            blob.upload_from_string("unused")
 
-    downloaded_file = xref_dir.joinpath("test/xrefmap.yml")
-    assert downloaded_file.exists()
-    assert len(xrefs) > 0
 
-    shutil.rmtree(xref_dir)
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("http://google.com", "http://google.com"),
+        ("devsite://does/not/exist", ""),
+        ("devsite://does/not/exist@latest", ""),
+        ("devsite://dotnet/my-pkg@1.0.0", "xrefs/dotnet-my-pkg-1.0.0.tar.gz.yml"),
+        ("devsite://dotnet/my-pkg", "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml"),
+        ("devsite://dotnet/my-pkg@latest", "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml"),
+    ],
+)
+def test_get_xref(test_input, expected, tmpdir, xref_test_blobs):
+    test_bucket, credentials, storage_client = test_init()
+    bucket = storage_client.get_bucket(test_bucket)
+
+    tmpdir = pathlib.Path(tmpdir)
+    got = generate.get_xref(test_input, bucket, tmpdir)
+
+    if ":" in expected:
+        assert got == expected
+        return
+    if expected == "":
+        assert got == expected
+        return
+    expected_path = tmpdir.joinpath(expected)
+    assert str(expected_path) == got
+    assert expected_path.exists(), f"expected {expected_path} to exist"
 
 
 def test_add_prettyprint():


### PR DESCRIPTION
This changes xref support to require libraries to specify the exact xref
files we need. This has two clear benefits:

* Efficiency. We're no longer downloading every xrefmap for every
  library.
* Dependency versioning support. If there are multiple versions of the
  same package (1.0.0, 2.0.0, etc.), they would all register a similar set
  of xrefmaps. If we download and plug in all of those, the behavior would
  be undefined and probably wrong.

I chose to log an error, but not fail the build, when an xref fails to resolve.
That way, if docs are generated in the "wrong" order, we can still make
progress.

Fixes #70.