### PR TITLE
feat: rebuild HTML on YAML update

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -376,12 +376,11 @@ def build_new_docs(bucket_name, credentials):
     all_blobs = list(client.list_blobs(bucket_name))
     docfx_blobs = [blob for blob in all_blobs if blob.name.startswith(DOCFX_PREFIX)]
     other_blobs = {b.name: b for b in all_blobs if not b.name.startswith(DOCFX_PREFIX)}
-    other_names = set(other_blobs.keys())
 
     new_blobs = []
     for blob in docfx_blobs:
         new_name = blob.name[len(DOCFX_PREFIX) :]
-        if new_name not in other_names:
+        if new_name not in other_blobs:
             new_blobs.append(blob)
         else:
             # For existing blobs, re-build the docs if the YAML blob is newer

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -392,6 +392,17 @@ def build_new_docs(bucket_name, credentials):
         new_name = blob.name[len(DOCFX_PREFIX) :]
         if new_name not in other_names:
             new_blobs.append(blob)
+        else:
+            # For existing blobs, re-build the docs if the YAML blob is newer
+            # than the existing HTML blob
+            yaml_last_updated = blob.updated
+
+            html_blob = client.bucket(bucket_name).get_blob(new_name)
+            html_last_updated = html_blob.updated
+
+            if yaml_last_updated > html_last_updated:
+                new_blobs.append(blob)
+
     build_blobs(client, new_blobs, credentials)
 
 

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -384,8 +384,8 @@ def build_new_docs(bucket_name, credentials):
     client = storage_client(credentials)
     all_blobs = list(client.list_blobs(bucket_name))
     docfx_blobs = [blob for blob in all_blobs if blob.name.startswith(DOCFX_PREFIX)]
-    other_blobs = [blob for blob in all_blobs if not blob.name.startswith(DOCFX_PREFIX)]
-    other_names = set(map(lambda b: b.name, other_blobs))
+    other_blobs = {b.name: b for b in all_blobs if not b.name.startswith(DOCFX_PREFIX)}
+    other_names = set(other_blobs.keys())
 
     new_blobs = []
     for blob in docfx_blobs:
@@ -397,7 +397,7 @@ def build_new_docs(bucket_name, credentials):
             # than the existing HTML blob
             yaml_last_updated = blob.updated
 
-            html_blob = client.bucket(bucket_name).get_blob(new_name)
+            html_blob = other_blobs[new_name]
             html_last_updated = html_blob.updated
 
             if yaml_last_updated > html_last_updated:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -60,6 +60,22 @@ def test_init():
     return test_bucket, credentials, storage_client
 
 
+def upload_yaml(cwd, credentials, test_bucket):
+    # Upload DocFX YAML to test with.
+    shell.run(
+        [
+            "docuploader",
+            "upload",
+            ".",
+            f"--credentials={credentials}",
+            f"--staging-bucket={test_bucket}",
+            "--destination-prefix=docfx",
+        ],
+        cwd=cwd,
+        hide_output=False,
+    )
+
+
 # Fetches and uploads the blobs used for testing.
 def setup_testdata(cwd, storage_client, credentials, test_bucket):
     yaml_blob_name = "docfx-python-doc-pipeline-test-2.1.1.tar.gz"
@@ -79,19 +95,7 @@ def setup_testdata(cwd, storage_client, credentials, test_bucket):
 
     start_blobs = list(storage_client.list_blobs(test_bucket))
 
-    # Upload DocFX YAML to test with.
-    shell.run(
-        [
-            "docuploader",
-            "upload",
-            ".",
-            f"--credentials={credentials}",
-            f"--staging-bucket={test_bucket}",
-            "--destination-prefix=docfx",
-        ],
-        cwd=cwd,
-        hide_output=False,
-    )
+    upload_yaml(cwd, credentials, test_bucket)
 
     # Make sure docuploader succeeded.
     assert (
@@ -258,19 +262,34 @@ def test_generate(yaml_dir, tmpdir):
     t3 = html_blob.updated
     assert t2 != t3
 
-    # Force generation of Python docs and verify timestamp
+    # Force generation of Python docs and verify timestamp.
     language = "python"
     generate.build_language_docs(test_bucket, language, credentials)
     html_blob = bucket.get_blob(html_blob.name)
     t4 = html_blob.updated
     assert t3 != t4
 
-    # Force generation of Go docs, verify timestamp does not change
+    # Force generation of Go docs, verify timestamp does not change.
     language = "go"
     generate.build_language_docs(test_bucket, language, credentials)
     html_blob = bucket.get_blob(html_blob.name)
     t5 = html_blob.updated
     assert t4 == t5
+
+    # Force regeneration of a single doc with old YAML and verify
+    # timestamp does not change.
+    generate.build_new_docs(test_bucket, credentials)
+    html_blob = bucket.get_blob(html_blob.name)
+    t6 = html_blob.updated
+    assert t5 == t6
+
+    # Force regeneration of a single doc with updated YAML and verify
+    # timestamp does not change.
+    upload_yaml(yaml_dir, credentials, test_bucket)
+    generate.build_new_docs(test_bucket, credentials)
+    html_blob = bucket.get_blob(html_blob.name)
+    t7 = html_blob.updated
+    assert t6 != t7
 
 
 def test_local_generate(yaml_dir, tmpdir):

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -269,7 +269,7 @@ def test_generate(yaml_dir, tmpdir):
     t4 = html_blob.updated
     assert t3 != t4
 
-    # Force generation of Go docs, verify timestamp does not change.
+    # Force generation of Go docs, verify Python HTML timestamp does not change.
     language = "go"
     generate.build_language_docs(test_bucket, language, credentials)
     html_blob = bucket.get_blob(html_blob.name)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -283,8 +283,7 @@ def test_generate(yaml_dir, tmpdir):
     t6 = html_blob.updated
     assert t5 == t6
 
-    # Force regeneration of a single doc with updated YAML and verify
-    # timestamp does not change.
+    # Update the YAML, build new docs, and verify the HTML was updated.
     upload_yaml(yaml_dir, credentials, test_bucket)
     generate.build_new_docs(test_bucket, credentials)
     html_blob = bucket.get_blob(html_blob.name)


### PR DESCRIPTION
There is existing support when building new docs to see if the HTML for a specified YAML blob exists. Extending the support
for existing HTML blobs to automatically rebuild docs on YAML update.

Minor refactoring on test case, updated to include two new cases to reflect this change.

Fixes #66 
