### PR TITLE
feat!: remove --credentials arg in favor of Application Default Credentials

### DIFF
--- a/docpipeline/__main__.py
+++ b/docpipeline/__main__.py
@@ -46,8 +46,13 @@ def main():
 
 @main.command()
 @click.argument("bucket_name")
-def build_new_docs(bucket_name):
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
+@click.option(
+    "--credentials",
+    default="",
+    help="Path to the credentials file to use for Google Cloud Storage.",
+)
+def build_new_docs(bucket_name, credentials):
+    credentials, project_id = docuploader.credentials.find(credentials_file=credentials)
     verify()
 
     try:
@@ -59,8 +64,13 @@ def build_new_docs(bucket_name):
 
 @main.command()
 @click.argument("bucket_name")
-def build_all_docs(bucket_name):
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
+@click.option(
+    "--credentials",
+    default="",
+    help="Path to the credentials file to use for Google Cloud Storage.",
+)
+def build_all_docs(bucket_name, credentials):
+    credentials, project_id = docuploader.credentials.find(credentials_file=credentials)
     verify()
 
     try:
@@ -73,8 +83,13 @@ def build_all_docs(bucket_name):
 @main.command()
 @click.argument("bucket_name")
 @click.argument("object_name")
-def build_one_doc(bucket_name, object_name):
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
+@click.option(
+    "--credentials",
+    default="",
+    help="Path to the credentials file to use for Google Cloud Storage.",
+)
+def build_one_doc(bucket_name, object_name, credentials):
+    credentials, project_id = docuploader.credentials.find(credentials_file=credentials)
     verify()
 
     try:
@@ -87,8 +102,13 @@ def build_one_doc(bucket_name, object_name):
 @main.command()
 @click.argument("bucket_name")
 @click.argument("language")
-def build_language_docs(bucket_name, language):
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
+@click.option(
+    "--credentials",
+    default="",
+    help="Path to the credentials file to use for Google Cloud Storage.",
+)
+def build_language_docs(bucket_name, language, credentials):
+    credentials, project_id = docuploader.credentials.find(credentials_file=credentials)
     verify()
 
     try:

--- a/docpipeline/__main__.py
+++ b/docpipeline/__main__.py
@@ -31,16 +31,7 @@ REQUIRED_CMDS = ["docfx", "docuploader"]
 VERSION = "0.0.0-dev"
 
 
-def verify(credentials):
-    if not credentials:
-        log.error(
-            (
-                "You need credentials to run this! Specify --credentials on",
-                "the command line.",
-            )
-        )
-        return sys.exit(1)
-
+def verify():
     for cmd in REQUIRED_CMDS:
         if shutil.which(cmd) is None:
             log.error(f"Could not find {cmd} command!")
@@ -55,14 +46,9 @@ def main():
 
 @main.command()
 @click.argument("bucket_name")
-@click.option(
-    "--credentials",
-    default="",
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_new_docs(bucket_name, credentials):
-    credentials = docuploader.credentials.find(credentials_file=credentials)[0]
-    verify(credentials)
+def build_new_docs(bucket_name):
+    credentials = docuploader.credentials.find(credentials_file="")[0]
+    verify()
 
     try:
         generate.build_new_docs(bucket_name, credentials)
@@ -73,14 +59,9 @@ def build_new_docs(bucket_name, credentials):
 
 @main.command()
 @click.argument("bucket_name")
-@click.option(
-    "--credentials",
-    default="",
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_all_docs(bucket_name, credentials):
-    credentials = docuploader.credentials.find(credentials_file=credentials)[0]
-    verify(credentials)
+def build_all_docs(bucket_name):
+    credentials = docuploader.credentials.find(credentials_file="")[0]
+    verify()
 
     try:
         generate.build_all_docs(bucket_name, credentials)
@@ -92,14 +73,9 @@ def build_all_docs(bucket_name, credentials):
 @main.command()
 @click.argument("bucket_name")
 @click.argument("object_name")
-@click.option(
-    "--credentials",
-    default="",
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_one_doc(bucket_name, object_name, credentials):
-    credentials = docuploader.credentials.find(credentials_file=credentials)[0]
-    verify(credentials)
+def build_one_doc(bucket_name, object_name):
+    credentials = docuploader.credentials.find(credentials_file="")[0]
+    verify()
 
     try:
         generate.build_one_doc(bucket_name, object_name, credentials)
@@ -111,14 +87,9 @@ def build_one_doc(bucket_name, object_name, credentials):
 @main.command()
 @click.argument("bucket_name")
 @click.argument("language")
-@click.option(
-    "--credentials",
-    default="",
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_language_docs(bucket_name, language, credentials):
-    credentials = docuploader.credentials.find(credentials_file=credentials)[0]
-    verify(credentials)
+def build_language_docs(bucket_name, language):
+    credentials = docuploader.credentials.find(credentials_file="")[0]
+    verify()
 
     try:
         generate.build_language_docs(bucket_name, language, credentials)

--- a/docpipeline/__main__.py
+++ b/docpipeline/__main__.py
@@ -47,11 +47,11 @@ def main():
 @main.command()
 @click.argument("bucket_name")
 def build_new_docs(bucket_name):
-    credentials = docuploader.credentials.find(credentials_file="")[0]
+    credentials, project_id = docuploader.credentials.find(credentials_file="")
     verify()
 
     try:
-        generate.build_new_docs(bucket_name, credentials)
+        generate.build_new_docs(bucket_name, credentials, project_id)
     except Exception as e:
         log.error(e)
         sys.exit(1)
@@ -60,11 +60,11 @@ def build_new_docs(bucket_name):
 @main.command()
 @click.argument("bucket_name")
 def build_all_docs(bucket_name):
-    credentials = docuploader.credentials.find(credentials_file="")[0]
+    credentials, project_id = docuploader.credentials.find(credentials_file="")
     verify()
 
     try:
-        generate.build_all_docs(bucket_name, credentials)
+        generate.build_all_docs(bucket_name, credentials, project_id)
     except Exception as e:
         log.error(e)
         sys.exit(1)
@@ -74,11 +74,11 @@ def build_all_docs(bucket_name):
 @click.argument("bucket_name")
 @click.argument("object_name")
 def build_one_doc(bucket_name, object_name):
-    credentials = docuploader.credentials.find(credentials_file="")[0]
+    credentials, project_id = docuploader.credentials.find(credentials_file="")
     verify()
 
     try:
-        generate.build_one_doc(bucket_name, object_name, credentials)
+        generate.build_one_doc(bucket_name, object_name, credentials, project_id)
     except Exception as e:
         log.error(e)
         sys.exit(1)
@@ -88,11 +88,11 @@ def build_one_doc(bucket_name, object_name):
 @click.argument("bucket_name")
 @click.argument("language")
 def build_language_docs(bucket_name, language):
-    credentials = docuploader.credentials.find(credentials_file="")[0]
+    credentials, project_id = docuploader.credentials.find(credentials_file="")
     verify()
 
     try:
-        generate.build_language_docs(bucket_name, language, credentials)
+        generate.build_language_docs(bucket_name, language, credentials, project_id)
     except Exception as e:
         log.error(e)
         sys.exit(1)

--- a/docpipeline/__main__.py
+++ b/docpipeline/__main__.py
@@ -46,13 +46,8 @@ def main():
 
 @main.command()
 @click.argument("bucket_name")
-@click.option(
-    "--credentials",
-    default="",
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_new_docs(bucket_name, credentials):
-    credentials, project_id = docuploader.credentials.find(credentials_file=credentials)
+def build_new_docs(bucket_name):
+    credentials, project_id = docuploader.credentials.find(credentials_file="")
     verify()
 
     try:
@@ -64,13 +59,8 @@ def build_new_docs(bucket_name, credentials):
 
 @main.command()
 @click.argument("bucket_name")
-@click.option(
-    "--credentials",
-    default="",
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_all_docs(bucket_name, credentials):
-    credentials, project_id = docuploader.credentials.find(credentials_file=credentials)
+def build_all_docs(bucket_name):
+    credentials, project_id = docuploader.credentials.find(credentials_file="")
     verify()
 
     try:
@@ -83,13 +73,8 @@ def build_all_docs(bucket_name, credentials):
 @main.command()
 @click.argument("bucket_name")
 @click.argument("object_name")
-@click.option(
-    "--credentials",
-    default="",
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_one_doc(bucket_name, object_name, credentials):
-    credentials, project_id = docuploader.credentials.find(credentials_file=credentials)
+def build_one_doc(bucket_name, object_name):
+    credentials, project_id = docuploader.credentials.find(credentials_file="")
     verify()
 
     try:
@@ -102,13 +87,8 @@ def build_one_doc(bucket_name, object_name, credentials):
 @main.command()
 @click.argument("bucket_name")
 @click.argument("language")
-@click.option(
-    "--credentials",
-    default="",
-    help="Path to the credentials file to use for Google Cloud Storage.",
-)
-def build_language_docs(bucket_name, language, credentials):
-    credentials, project_id = docuploader.credentials.find(credentials_file=credentials)
+def build_language_docs(bucket_name, language):
+    credentials, project_id = docuploader.credentials.find(credentials_file="")
     verify()
 
     try:

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -249,7 +249,6 @@ def process_blob(blob, credentials, devsite_template):
             "docuploader",
             "upload",
             ".",
-            f"--credentials={credentials}",
             f"--staging-bucket={blob.bucket.name}",
         ],
         cwd=site_path,
@@ -348,11 +347,8 @@ def build_blobs(client, blobs, credentials):
 
 
 def storage_client(credentials):
-    parsed_credentials = service_account.Credentials.from_service_account_file(
-        credentials
-    )
     return storage.Client(
-        project=parsed_credentials.project_id, credentials=parsed_credentials
+        project=credentials.project_id, credentials=credentials
     )
 
 

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -221,7 +221,7 @@ def build_and_format(blob, is_bucket, devsite_template):
     return tmp_path, metadata, site_path
 
 
-def process_blob(blob, credentials, devsite_template):
+def process_blob(blob, devsite_template):
     is_bucket = True
     tmp_path, metadata, site_path = build_and_format(blob, is_bucket, devsite_template)
 
@@ -309,7 +309,7 @@ def version_sort(v):
     return semver.VersionInfo.parse(v)
 
 
-def build_blobs(client, blobs, credentials, project_id):
+def build_blobs(client, blobs):
     num = len(blobs)
     if num == 0:
         log.success("No blobs to process!")
@@ -328,7 +328,7 @@ def build_blobs(client, blobs, credentials, project_id):
     for i, blob in enumerate(blobs):
         try:
             log.info(f"Processing {i+1} of {len(blobs)}: {blob.name}...")
-            process_blob(blob, credentials, devsite_template)
+            process_blob(blob, devsite_template)
         except Exception as e:
             # Keep processing the other files if an error occurs.
             log.error(f"Error processing {blob.name}:\n\n{e}")
@@ -349,7 +349,7 @@ def build_all_docs(bucket_name, credentials, project_id):
     client = storage.Client(project=project_id, credentials=credentials)
     all_blobs = client.list_blobs(bucket_name)
     docfx_blobs = [blob for blob in all_blobs if blob.name.startswith(DOCFX_PREFIX)]
-    build_blobs(client, docfx_blobs, credentials, project_id)
+    build_blobs(client, docfx_blobs)
 
 
 def build_one_doc(bucket_name, object_name, credentials, project_id):
@@ -357,7 +357,7 @@ def build_one_doc(bucket_name, object_name, credentials, project_id):
     blob = client.bucket(bucket_name).get_blob(object_name)
     if blob is None:
         raise Exception(f"Could not find gs://{bucket_name}/{object_name}!")
-    build_blobs(client, [blob], credentials, project_id)
+    build_blobs(client, [blob])
 
 
 def build_new_docs(bucket_name, credentials, project_id):
@@ -382,7 +382,7 @@ def build_new_docs(bucket_name, credentials, project_id):
             if yaml_last_updated > html_last_updated:
                 new_blobs.append(blob)
 
-    build_blobs(client, new_blobs, credentials, project_id)
+    build_blobs(client, new_blobs)
 
 
 def build_language_docs(bucket_name, language, credentials, project_id):
@@ -390,4 +390,4 @@ def build_language_docs(bucket_name, language, credentials, project_id):
     all_blobs = client.list_blobs(bucket_name)
     language_prefix = DOCFX_PREFIX + language + "-"
     docfx_blobs = [blob for blob in all_blobs if blob.name.startswith(language_prefix)]
-    build_blobs(client, docfx_blobs, credentials, project_id)
+    build_blobs(client, docfx_blobs)

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -310,7 +310,7 @@ def version_sort(v):
     return semver.VersionInfo.parse(v)
 
 
-def build_blobs(client, blobs, credentials):
+def build_blobs(client, blobs, credentials, project_id):
     num = len(blobs)
     if num == 0:
         log.success("No blobs to process!")
@@ -346,29 +346,23 @@ def build_blobs(client, blobs, credentials):
     log.success("Done!")
 
 
-def storage_client(credentials):
-    return storage.Client(
-        project=credentials.project_id, credentials=credentials
-    )
-
-
-def build_all_docs(bucket_name, credentials):
-    client = storage_client(credentials)
+def build_all_docs(bucket_name, credentials, project_id):
+    client = storage.Client(project=project_id, credentials=credentials)
     all_blobs = client.list_blobs(bucket_name)
     docfx_blobs = [blob for blob in all_blobs if blob.name.startswith(DOCFX_PREFIX)]
-    build_blobs(client, docfx_blobs, credentials)
+    build_blobs(client, docfx_blobs, credentials, project_id)
 
 
-def build_one_doc(bucket_name, object_name, credentials):
-    client = storage_client(credentials)
+def build_one_doc(bucket_name, object_name, credentials, project_id):
+    client = storage.Client(project=project_id, credentials=credentials)
     blob = client.bucket(bucket_name).get_blob(object_name)
     if blob is None:
         raise Exception(f"Could not find gs://{bucket_name}/{object_name}!")
-    build_blobs(client, [blob], credentials)
+    build_blobs(client, [blob], credentials, project_id)
 
 
-def build_new_docs(bucket_name, credentials):
-    client = storage_client(credentials)
+def build_new_docs(bucket_name, credentials, project_id):
+    client = storage.Client(project=project_id, credentials=credentials)
     all_blobs = list(client.list_blobs(bucket_name))
     docfx_blobs = [blob for blob in all_blobs if blob.name.startswith(DOCFX_PREFIX)]
     other_blobs = {b.name: b for b in all_blobs if not b.name.startswith(DOCFX_PREFIX)}
@@ -389,12 +383,12 @@ def build_new_docs(bucket_name, credentials):
             if yaml_last_updated > html_last_updated:
                 new_blobs.append(blob)
 
-    build_blobs(client, new_blobs, credentials)
+    build_blobs(client, new_blobs, credentials, project_id)
 
 
-def build_language_docs(bucket_name, language, credentials):
-    client = storage_client(credentials)
+def build_language_docs(bucket_name, language, credentials, project_id):
+    client = storage.Client(project=project_id, credentials=credentials)
     all_blobs = client.list_blobs(bucket_name)
     language_prefix = DOCFX_PREFIX + language + "-"
     docfx_blobs = [blob for blob in all_blobs if blob.name.startswith(language_prefix)]
-    build_blobs(client, docfx_blobs, credentials)
+    build_blobs(client, docfx_blobs, credentials, project_id)

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -20,7 +20,6 @@ import tarfile
 from docuploader import log, shell, tar
 from docuploader.protos import metadata_pb2
 from google.cloud import storage
-from google.oauth2 import service_account
 from google.protobuf import text_format, json_format
 from docpipeline import prepare
 


### PR DESCRIPTION
We should use ADC (e.g. `GOOGLE_APPLICATION_CREDENTIALS`) instead.

Alternatively, we could keep the argument, but this PR would have to add
code rather than mostly delete code.

Once `docuploader.credentials.find` makes `credentials_file` optional, we can remove that arg.