### PR TITLE
fix: configure docfx to not have version in help URL

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -96,10 +96,13 @@ def format_docfx_json(metadata):
     pkg = metadata.name
     xrefs = ", ".join([f'"{xref}"' for xref in metadata.xrefs if xref != ""])
     xref_services = ", ".join([f'"{xref}"' for xref in metadata.xref_services])
+    path = f"/{metadata.language}/docs/reference/{pkg}"
+    if pkg != "help":
+        path += "/latest"
 
     return DOCFX_JSON_TEMPLATE.format(
         package=pkg,
-        path=f"/{metadata.language}/docs/reference/{pkg}/latest",
+        path=path,
         project_path=f"/{metadata.language}/",
         xrefs=xrefs,
         xref_services=xref_services,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -385,6 +385,48 @@ class TestGenerate(unittest.TestCase):
 
         self.assertMultiLineEqual(got, want)
 
+    def test_format_docfx_json_help(self):
+        self.maxDiff = None
+        metadata = metadata_pb2.Metadata()
+        metadata.name = "help"
+        metadata.language = "dotnet"
+
+        want = """
+{
+  "build": {
+    "content": [
+      {
+        "files": ["**/*.yml", "**/*.md"],
+        "src": "obj/api"
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "help",
+      "_disableContribution": true,
+      "_appFooter": " ",
+      "_disableNavbar": true,
+      "_disableBreadcrumb": true,
+      "_enableSearch": false,
+      "_disableToc": true,
+      "_disableSideFilter": true,
+      "_disableAffix": true,
+      "_disableFooter": true,
+      "_rootPath": "/dotnet/docs/reference/help",
+      "_projectPath": "/dotnet/"
+    },
+    "overwrite": [
+      "obj/examples/*.md"
+    ],
+    "dest": "site",
+    "xref": [],
+    "xrefService": [],
+  }
+}
+"""
+        got = generate.format_docfx_json(metadata)
+
+        self.assertMultiLineEqual(got, want)
+
 
 @pytest.mark.parametrize(
     "lang,name,expected",


### PR DESCRIPTION
Related to #85, which updated the xref map.