### PR TITLE
feat: support docs.metadata stem field

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -97,6 +97,8 @@ def format_docfx_json(metadata):
     xrefs = ", ".join([f'"{xref}"' for xref in metadata.xrefs if xref != ""])
     xref_services = ", ".join([f'"{xref}"' for xref in metadata.xref_services])
     path = f"/{metadata.language}/docs/reference/{pkg}"
+    if metadata.stem != "":
+        path = metadata.stem
     if pkg != "help":
         path += "/latest"
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -390,6 +390,7 @@ class TestGenerate(unittest.TestCase):
         metadata = metadata_pb2.Metadata()
         metadata.name = "help"
         metadata.language = "dotnet"
+        metadata.stem = "/dotnet/is/awesome"
 
         want = """
 {
@@ -411,7 +412,7 @@ class TestGenerate(unittest.TestCase):
       "_disableSideFilter": true,
       "_disableAffix": true,
       "_disableFooter": true,
-      "_rootPath": "/dotnet/docs/reference/help",
+      "_rootPath": "/dotnet/is/awesome",
       "_projectPath": "/dotnet/"
     },
     "overwrite": [


### PR DESCRIPTION
This will allow libraries to specify a different stem for the final output URL. Some packages need a different URL.