### PR TITLE
feat: send xUnit XML to flakybot for builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ archives
 
 canonical/canonical
 canonical/*prof
+
+**/*sponge_log.xml

--- a/ci/common.cfg
+++ b/ci/common.cfg
@@ -57,3 +57,5 @@ before_action {
     }
   }
 }
+
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -16,6 +16,7 @@ import pathlib
 import shutil
 import tempfile
 import tarfile
+import xml.etree.ElementTree as ET
 
 from docuploader import log, shell, tar
 from docuploader.protos import metadata_pb2
@@ -332,6 +333,7 @@ def build_blobs(blobs):
 
     # Process every blob.
     failures = []
+    successes = []
     for i, blob in enumerate(blobs):
         try:
             log.info(f"Processing {i+1} of {len(blobs)}: {blob.name}...")
@@ -343,12 +345,16 @@ def build_blobs(blobs):
                     )
                 )
             process_blob(blob, devsite_template)
+            successes.append(blob.name)
         except Exception as e:
             # Keep processing the other files if an error occurs.
             log.error(f"Error processing {blob.name}:\n\n{e}")
             failures.append(blob.name)
 
     shutil.rmtree(templates_dir)
+
+    with open("sponge_log.xml", "w") as f:
+        write_xunit(f, successes, failures)
 
     if len(failures) > 0:
         failure_str = "\n".join(failures)
@@ -401,3 +407,29 @@ def build_language_docs(bucket_name, language, storage_client):
     language_prefix = DOCFX_PREFIX + language + "-"
     docfx_blobs = [blob for blob in all_blobs if blob.name.startswith(language_prefix)]
     build_blobs(docfx_blobs)
+
+
+def write_xunit(f, successes, failures):
+    testsuites = ET.Element("testsuites")
+    testsuite = ET.SubElement(
+        testsuites,
+        "testsuite",
+        attrib={
+            "tests": str(len(successes) + len(failures)),
+            "failures": str(len(failures)),
+            "name": "github.com/googleapis/doc-pipeline",
+        },
+    )
+    for success in successes:
+        ET.SubElement(
+            testsuite, "testcase", attrib={"classname": "build", "name": success}
+        )
+    for failure in failures:
+        testcase = ET.SubElement(
+            testsuite, "testcase", attrib={"classname": "build", "name": failure}
+        )
+        ET.SubElement(testcase, "failure", attrib={"message": "Failed"})
+
+    tree = ET.ElementTree(element=testsuites)
+    ET.indent(tree)
+    tree.write(f, encoding="unicode")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
 import pathlib
 import shutil
@@ -427,6 +428,22 @@ class TestGenerate(unittest.TestCase):
         got = generate.format_docfx_json(metadata)
 
         self.assertMultiLineEqual(got, want)
+
+    def test_write_xunit(self):
+        want = """<testsuites>
+  <testsuite tests="2" failures="1" name="github.com/googleapis/doc-pipeline">
+    <testcase classname="build" name="hello" />
+    <testcase classname="build" name="goodbye">
+      <failure message="Failed" />
+    </testcase>
+  </testsuite>
+</testsuites>"""
+        f = io.StringIO()
+        successes = ["hello"]
+        failures = ["goodbye"]
+        generate.write_xunit(f, successes, failures)
+        got = f.getvalue()
+        self.assertMultiLineEqual(want, got)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This will lead to filing issues on the doc-pipeline repo whenever a blob fails to build.

We may decide to file issues on the source repos in the future.

Fixes #78.