### PR TITLE
chore: add KOKORO_BUILD_ARTIFACTS_SUBDIR to Trampoline config

### DIFF
--- a/.trampolinerc
+++ b/.trampolinerc
@@ -25,6 +25,7 @@ pass_down_envvars+=(
     "LANGUAGE"           # For specifying specific language builds.
     "INPUT"              # For specifying local input source.
     "BLOB_TO_DELETE"     # For delete-blob.
+    "KOKORO_BUILD_ARTIFACTS_SUBDIR" # For job type detection.
 )
 
 # Prevent unintentional override on the default image.

--- a/generate.sh
+++ b/generate.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 set -e
+set -x
 
 # Add the path where docuploader gets installed to PATH.
 export PATH=$PATH:${HOME}/.local/bin


### PR DESCRIPTION
I confirmed this works by running generate-prod off of my branch.

Updates #78.