### PR TITLE
chore: extend xUnit package name

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -417,7 +417,7 @@ def write_xunit(f, successes, failures):
         attrib={
             "tests": str(len(successes) + len(failures)),
             "failures": str(len(failures)),
-            "name": "github.com/googleapis/doc-pipeline",
+            "name": "github.com/googleapis/doc-pipeline/generate",
         },
     )
     for success in successes:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -431,7 +431,7 @@ class TestGenerate(unittest.TestCase):
 
     def test_write_xunit(self):
         want = """<testsuites>
-  <testsuite tests="2" failures="1" name="github.com/googleapis/doc-pipeline">
+  <testsuite tests="2" failures="1" name="github.com/googleapis/doc-pipeline/generate">
     <testcase classname="build" name="hello" />
     <testcase classname="build" name="goodbye">
       <failure message="Failed" />


### PR DESCRIPTION
Flakybot removes the `github.com/org/repo/` prefix, if it exists, before
filing issues. So, this will lead to issues with the prefix `generate`.

See https://github.com/googleapis/repo-automation-bots/blob/33bcaea59e9b37d01d1fd3004a8094bc1b2a3256/packages/flakybot/src/flakybot.ts#L891.