### PR TITLE
feat: add Python to genrobots

### DIFF
--- a/genrobots/main.go
+++ b/genrobots/main.go
@@ -103,7 +103,8 @@ func names(ctx context.Context, bucket *storage.BucketHandle) (map[string]struct
 		}
 		if !strings.HasPrefix(obj.Name, "dotnet") &&
 			!strings.HasPrefix(obj.Name, "go") &&
-			!strings.HasPrefix(obj.Name, "nodejs") {
+			!strings.HasPrefix(obj.Name, "nodejs") &&
+			!strings.HasPrefix(obj.Name, "python") {
 			continue
 		}
 		name, err := trimVersion(obj.Name)


### PR DESCRIPTION
Python blobs are now ready to be added to robots.txt.

Fixes b/192475931.