### PR TITLE
fix: add prettyprint to any code tag

### DIFF
--- a/docpipeline/prepare.py
+++ b/docpipeline/prepare.py
@@ -24,8 +24,7 @@ def add_prettyprint(output_path):
             '<code class="lang-'.encode(), '<code class="prettyprint lang-'.encode()
         )
         html = html.replace(  # Add prettyprint to Nodejs examples
-            '<code translate="no" dir="ltr">'.encode(),
-            '<code class="prettyprint" translate="no" dir="ltr">'.encode(),
+            "<pre><code>".encode(), '<pre class="prettyprint"><code>'.encode()
         )
         with open(file, "wb") as file_handle:
             file_handle.write(html)

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -39,9 +39,13 @@ def test_add_prettyprint():
         },
         {
             "name": "four.html",
-            "input": '<code translate="no" dir="ltr">Node.js example code</code>',
-            "want": '<code class="prettyprint" translate="no" '
-            'dir="ltr">Node.js example code</code>',
+            "input": "<pre><code>Node.js example code</code>",
+            "want": '<pre class="prettyprint"><code>Node.js example code</code>',
+        },
+        {
+            "name": "five.html",
+            "input": '<pre><code class="specific class">nothing to do</code>',
+            "want": '<pre><code class="specific class">nothing to do</code>',
         },
     ]
 


### PR DESCRIPTION
`translate` and `directory` get added later in the pipeline. Thus adding prettyprint
to any code tag that doesn't specify a language.
