### PR TITLE
Revert "fix: add prettyprint to code tags without classes (#149)"

### DIFF
--- a/docpipeline/prepare.py
+++ b/docpipeline/prepare.py
@@ -23,9 +23,5 @@ def add_prettyprint(output_path):
         html = html.replace(
             '<code class="lang-'.encode(), '<code class="prettyprint lang-'.encode()
         )
-        html = html.replace(  # Add prettyprint to Nodejs examples
-            '<code translate="no" dir="ltr">'.encode(),
-            '<code class="prettyprint" translate="no" dir="ltr">'.encode(),
-        )
         with open(file, "wb") as file_handle:
             file_handle.write(html)

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -37,12 +37,6 @@ def test_add_prettyprint():
             "input": "nothing to do",
             "want": "nothing to do",
         },
-        {
-            "name": "four.html",
-            "input": '<code translate="no" dir="ltr">Node.js example code</code>',
-            "want": '<code class="prettyprint" translate="no" '
-            'dir="ltr">Node.js example code</code>',
-        },
     ]
 
     for file in files:


### PR DESCRIPTION
This reverts commit 34ff164e342ae4655463b3483579deb45b0bdbab.
Add formatting in Node.js cloud-rad package instead of here, see
https://github.com/googleapis/nodejs-cloud-rad/pull/18
