### PR TITLE
fix: update project_path and book_path for local publishing

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -100,12 +100,13 @@ def format_docfx_json(metadata):
     xref_services = ", ".join([f'"{xref}"' for xref in metadata.xref_services])
     path = get_path(metadata)
     version = metadata.version
+    project_path = f"/{metadata.language}/docs/reference/"
 
     return DOCFX_JSON_TEMPLATE.format(
         package=pkg,
         package_version=version,
         path=path,
-        project_path=f"/{metadata.language}/",
+        project_path=project_path,
         xrefs=xrefs,
         xref_services=xref_services,
     )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -427,7 +427,7 @@ class TestGenerate(unittest.TestCase):
       "_disableAffix": true,
       "_disableFooter": true,
       "_rootPath": "/python/docs/reference/doc-pipeline/latest",
-      "_projectPath": "/python/"
+      "_projectPath": "/python/docs/reference/"
     },
     "overwrite": [
       "obj/examples/*.md"
@@ -471,7 +471,7 @@ class TestGenerate(unittest.TestCase):
       "_disableAffix": true,
       "_disableFooter": true,
       "_rootPath": "/dotnet/is/awesome",
-      "_projectPath": "/dotnet/"
+      "_projectPath": "/dotnet/docs/reference/"
     },
     "overwrite": [
       "obj/examples/*.md"


### PR DESCRIPTION
The book path won't be updated until https://github.com/googleapis/doc-templates/pull/380 is merged. Updating the `project_path` logic to include `docs/reference` to be up to date with our published pages at the moment.

This change will not affect publishing to c.g.c.

Fixes #201.