### PR TITLE
feat: rebuild all versions of pkg docs when any one version is updated

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -17,7 +17,7 @@ import pathlib
 import shutil
 import tempfile
 import tarfile
-from typing import Dict, List, Optional, Tuple
+from typing import DefaultDict, Dict, List, Optional, Tuple
 import xml.etree.ElementTree as ET
 
 from docuploader import log, shell, tar
@@ -370,9 +370,11 @@ def find_latest_blobs(
 
 def group_blobs_by_language_and_pkg(
     blobs: List[storage.Blob],
-) -> Dict[str, Dict[str, List[storage.Blob]]]:
+) -> DefaultDict[str, DefaultDict[str, List[storage.Blob]]]:
     """Gets a map from language to package name to a list of blobs."""
-    packages = collections.defaultdict(lambda: collections.defaultdict(list))
+    packages: DefaultDict[
+        str, DefaultDict[str, List[storage.Blob]]
+    ] = collections.defaultdict(lambda: collections.defaultdict(list))
     for blob in blobs:
         language, pkg = parse_blob_name(blob.name)
         packages[language][pkg].append(blob)
@@ -450,7 +452,7 @@ def build_one_doc(bucket_name, object_name, storage_client):
 
 
 def has_new_blob(
-    docfx_blobs: List[storage.Blob], html_blobs: List[storage.Blob]
+    docfx_blobs: List[storage.Blob], html_blobs: Dict[str, storage.Blob]
 ) -> bool:
     for blob in docfx_blobs:
         html_name = blob.name[len(DOCFX_PREFIX) :]
@@ -469,7 +471,7 @@ def has_new_blob(
     return False
 
 
-def build_new_docs(bucket_name, storage_client):
+def build_new_docs(bucket_name: str, storage_client: storage.Client):
     """Lazily builds just the new blobs in the bucket.
 
     If the DocFX blob of a package is uploaded for the first time or is newer

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -279,7 +279,7 @@ def test_generate(yaml_dir, tmpdir):
     t5 = html_blob.updated
     assert t4 == t5
 
-    # Force regeneration of a single doc with old YAML and verify
+    # Build new docs with unchanged YAML and verify the HTML
     # timestamp does not change.
     generate.build_new_docs(test_bucket, storage_client)
     html_blob = bucket.get_blob(html_blob.name)
@@ -330,6 +330,18 @@ def test_generate(yaml_dir, tmpdir):
     latest_html_blob = bucket.get_blob(latest_html_blob_name)
     t2_latest = latest_html_blob.updated
     assert t1_latest != t2_latest
+
+    # Update the YAML, build new docs, and verify the old HTML is updated.
+    upload_yaml(yaml_dir, test_bucket)
+    generate.build_new_docs(test_bucket, storage_client)
+    html_blob = bucket.get_blob(html_blob.name)
+    t10 = html_blob.updated
+    assert t9 != t10
+
+    # Also verify the latest HTML is updated.
+    latest_html_blob = bucket.get_blob(latest_html_blob_name)
+    t3_latest = latest_html_blob.updated
+    assert t2_latest != t3_latest
 
 
 def test_local_generate(yaml_dir, tmpdir):


### PR DESCRIPTION
This commit works toward being able to process all blobs for a given
package at the same time. For now, this will lead to additional
generation work without any impact on the final output. Future changes
will update the other generation options and do the actual content
analysis.

I confirmed the new test case fails without the `has_new_blob` changes.

This is working toward #214.