### PR TITLE
fix(docpipeline): re-instantiate blobs in case they changed

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -142,6 +142,15 @@ def setup_bucket_docfx(
     tar_filename = tmp_path.joinpath(blob.name)
     tar_filename.parent.mkdir(parents=True, exist_ok=True)
 
+    # Reinstantiate the blob in case it changed between listing and downloading.
+    blob = blob.bucket.blob(blob.name)
+    if not blob.exists():
+        raise ValueError(
+            (
+                f"Blob gs://{blob.bucket.name}/{blob.name} does"
+                "not exist (maybe it was deleted?)"
+            )
+        )
     blob.download_to_filename(tar_filename)
     log.info(f"Downloaded gs://{blob.bucket.name}/{blob.name} to {tar_filename}")
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -233,6 +233,19 @@ def test_setup_docfx(yaml_dir):
     assert metadata.name == "doc-pipeline-test"
 
 
+def test_setup_docfx_not_found():
+    test_bucket, storage_client = test_init()
+    tmp_path = pathlib.Path(tempfile.TemporaryDirectory(prefix="doc-pipeline.").name)
+    fake_blob = storage_client.bucket(test_bucket).blob("fake_blob_name")
+    with pytest.raises(ValueError):
+        generate.setup_bucket_docfx(
+            tmp_path,
+            pathlib.Path("/unused"),
+            pathlib.Path("/unused"),
+            fake_blob,
+        )
+
+
 def test_generate(yaml_dir, tmpdir):
     test_bucket, storage_client = test_init()
 


### PR DESCRIPTION
If a blob is modified or deleted between listing the blobs and downloading them, we get a 404 error. This PR re-instantiates the blob right before downloading and adds an extra check to make sure the blob exists, just in case it was deleted.

We _could_ check if the blob exists then recreate it if not, but we would still need _another_ check to make sure it exists after that. So, I kept it simple and just recreated the blob every time.

Fixes #106.