### PR TITLE
Revert "chore(deps): update python docker tag to v3.11"

### DIFF
--- a/docfx/Dockerfile
+++ b/docfx/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11-buster
+FROM python:3.10-buster
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH ${PATH}:/opt/docfx


### PR DESCRIPTION
Reverts googleapis/doc-pipeline#310. Shouldn't have made this change, we shouldn't be using 3.11 yet. 3.10 should be better and more stable.