### PR TITLE
fix: update flake8 formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,6 @@
 [flake8]
 max-line-length = 88
-ignore = E203, W503 # https://github.com/psf/black/issues/52
+ignore =
+    E203,
+    # https://github.com/psf/black/issues/52
+    W503,


### PR DESCRIPTION
Required since V6 that we must separate comments into a separate line.

Fixes #321.