### PR TITLE
feat: add new Java overview template

### DIFF
--- a/testdata/goldens/java/overview.html
+++ b/testdata/goldens/java/overview.html
@@ -12,7 +12,7 @@
   
     <h2 id="packages">
   </h2>
-      <h3><a class="xref" href="com.google.cloud.speech.v1.html">com.google.cloud.speech.v1</a></h3>
+      <h2><a class="xref" href="com.google.cloud.speech.v1.html">com.google.cloud.speech.v1</a></h2>
       <section><p>The interfaces provided are listed below, along with usage samples.</p>
 <p> <p><h2> SpeechClient </h2></p>
 <p> <p>Service Description: Service that implements Google Cloud Speech API.</p>
@@ -24,11 +24,11 @@
    RecognizeResponse response = speechClient.recognize(config, audio);
  }
  </code></pre></section>
-      <h3><a class="xref" href="com.google.cloud.speech.v1.stub.html">com.google.cloud.speech.v1.stub</a></h3>
+      <h2><a class="xref" href="com.google.cloud.speech.v1.stub.html">com.google.cloud.speech.v1.stub</a></h2>
       <section></section>
-      <h3><a class="xref" href="com.google.cloud.speech.v1beta1.html">com.google.cloud.speech.v1beta1</a></h3>
+      <h2><a class="xref" href="com.google.cloud.speech.v1beta1.html">com.google.cloud.speech.v1beta1</a></h2>
       <section></section>
-      <h3><a class="xref" href="com.google.cloud.speech.v1p1beta1.html">com.google.cloud.speech.v1p1beta1</a></h3>
+      <h2><a class="xref" href="com.google.cloud.speech.v1p1beta1.html">com.google.cloud.speech.v1p1beta1</a></h2>
       <section><p>The interfaces provided are listed below, along with usage samples.</p>
 <p> <p><h2> SpeechClient </h2></p>
 <p> <p>Service Description: Service that implements Google Cloud Speech API.</p>
@@ -52,7 +52,7 @@
    PhraseSet response = adaptationClient.createPhraseSet(parent, phraseSet, phraseSetId);
  }
  </code></pre></section>
-      <h3><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.html">com.google.cloud.speech.v1p1beta1.stub</a></h3>
+      <h2><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.html">com.google.cloud.speech.v1p1beta1.stub</a></h2>
       <section></section>
 </article>
     </div>

--- a/third_party/docfx/templates/devsite/ManagedReference.common.js
+++ b/third_party/docfx/templates/devsite/ManagedReference.common.js
@@ -18,6 +18,12 @@ exports.transform = function (model) {
   if (model.type) {
     switch (model.type.toLowerCase()) {
       case 'overview':
+        // For Java, use special template to ensure indentation is correct on righthand nav
+        if(model.langs[0] === "java" && model.children) {
+          model.isJavaOverview = true;
+          groupChildren(model, namespaceCategory);
+          break;
+        }
       case 'package':
       case 'namespace':
         model.isNamespace = true;

--- a/third_party/docfx/templates/devsite/ManagedReference.html.primary.tmpl
+++ b/third_party/docfx/templates/devsite/ManagedReference.html.primary.tmpl
@@ -11,3 +11,6 @@
 {{#isEnum}}
   {{>partials/enum}}
 {{/isEnum}}
+{{#isJavaOverview}}
+  {{>partials/JavaOverview}}
+{{/isJavaOverview}}

--- a/third_party/docfx/templates/devsite/partials/javaOverview.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/javaOverview.tmpl.partial
@@ -1,0 +1,19 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+{{>partials/disclaimer}}
+{{#summary}}
+<div class="markdown level0 summary">{{{summary}}}</div>
+{{/summary}}
+{{#conceptual}}
+<div class="markdown level0 conceptual">{{{conceptual}}}</div>
+{{/conceptual}}
+{{#remarks}}
+<div class="markdown level0 remarks">{{{remarks}}}</div>
+{{/remarks}}
+{{#children}}
+  <h2 id="{{id}}">{{>partials/namespaceSubtitle}}</h2>
+  {{#children}}
+    <h2><xref uid="{{uid}}" altProperty="fullName" displayProperty="name"/>{{#deprecated}} (deprecated){{/deprecated}}</h2>
+    <section>{{{summary}}}</section>
+  {{/children}}
+{{/children}}


### PR DESCRIPTION
Fix for https://github.com/googleapis/doc-pipeline/issues/436

parent bug: b/278903399
Corresponds to [R9] Confusing ‘On This Page’ Indentation on [go/cloud-java-rad-refactor](https://goto.google.com/cloud-java-rad-refactor) and slide 20 on [go/cloud-java-rad-visual-review](https://goto.google.com/cloud-java-rad-visual-review).

For example on: https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/overview

APIKeysClient is outdented even though it is a child of com.google.api.apikeys.v2.

This will be a two-part fix, with this being the template change, and https://github.com/googleapis/java-docfx-doclet/issues/178 being the doclet change