### PR TITLE
fix: add template for Java overview to fix indentation

### DIFF
--- a/testdata/goldens/java/overview.html
+++ b/testdata/goldens/java/overview.html
@@ -1,39 +1,39 @@
 ﻿<!DOCTYPE html>
 <html devsite="">
-  <head>
-    <meta name="project_path" value="/java/docs/reference/_project.yaml">
-    <meta name="book_path" value="/java/docs/reference/google-cloud-speech/latest/_book.yaml">
-  </head>
-  <body>
-    {% verbatim %}
-    <div>
-      <article data-uid="google-cloud-speech">
-<h1 class="page-title">google-cloud-speech overview (2.0.0)</h1>
-  
+<head>
+  <meta name="project_path" value="/java/docs/reference/_project.yaml">
+  <meta name="book_path" value="/java/docs/reference/google-cloud-speech/latest/_book.yaml">
+</head>
+<body>
+{% verbatim %}
+<div>
+  <article data-uid="google-cloud-speech">
+    <h1 class="page-title">google-cloud-speech overview (2.0.0)</h1>
+
     <h2 id="packages">
-  </h2>
-      <h3><a class="xref" href="com.google.cloud.speech.v1.html">com.google.cloud.speech.v1</a></h3>
-      <section><p>The interfaces provided are listed below, along with usage samples.</p>
-<p> <p><h2> SpeechClient </h2></p>
-<p> <p>Service Description: Service that implements Google Cloud Speech API.</p>
-<p> <p>Sample for SpeechClient:</p>
- <pre class="prettyprint lang-java"><code>
+    </h2>
+    <h2><a class="xref" href="com.google.cloud.speech.v1.html">com.google.cloud.speech.v1</a></h2>
+    <section><p>The interfaces provided are listed below, along with usage samples.</p>
+      <p> <p><h2> SpeechClient </h2></p>
+      <p> <p>Service Description: Service that implements Google Cloud Speech API.</p>
+      <p> <p>Sample for SpeechClient:</p>
+      <pre class="prettyprint lang-java"><code>
  try (SpeechClient speechClient = SpeechClient.create()) {
    RecognitionConfig config = RecognitionConfig.newBuilder().build();
    RecognitionAudio audio = RecognitionAudio.newBuilder().build();
    RecognizeResponse response = speechClient.recognize(config, audio);
  }
  </code></pre></section>
-      <h3><a class="xref" href="com.google.cloud.speech.v1.stub.html">com.google.cloud.speech.v1.stub</a></h3>
-      <section></section>
-      <h3><a class="xref" href="com.google.cloud.speech.v1beta1.html">com.google.cloud.speech.v1beta1</a></h3>
-      <section></section>
-      <h3><a class="xref" href="com.google.cloud.speech.v1p1beta1.html">com.google.cloud.speech.v1p1beta1</a></h3>
-      <section><p>The interfaces provided are listed below, along with usage samples.</p>
-<p> <p><h2> SpeechClient </h2></p>
-<p> <p>Service Description: Service that implements Google Cloud Speech API.</p>
-<p> <p>Sample for SpeechClient:</p>
- <pre class="prettyprint lang-java"><code>
+    <h2><a class="xref" href="com.google.cloud.speech.v1.stub.html">com.google.cloud.speech.v1.stub</a></h2>
+    <section></section>
+    <h2><a class="xref" href="com.google.cloud.speech.v1beta1.html">com.google.cloud.speech.v1beta1</a></h2>
+    <section></section>
+    <h2><a class="xref" href="com.google.cloud.speech.v1p1beta1.html">com.google.cloud.speech.v1p1beta1</a></h2>
+    <section><p>The interfaces provided are listed below, along with usage samples.</p>
+      <p> <p><h2> SpeechClient </h2></p>
+      <p> <p>Service Description: Service that implements Google Cloud Speech API.</p>
+      <p> <p>Sample for SpeechClient:</p>
+      <pre class="prettyprint lang-java"><code>
  try (SpeechClient speechClient = SpeechClient.create()) {
    RecognitionConfig config = RecognitionConfig.newBuilder().build();
    RecognitionAudio audio = RecognitionAudio.newBuilder().build();
@@ -41,10 +41,10 @@
  }
  </code></pre>
 
-<p> <p><h2> AdaptationClient </h2></p>
-<p> <p>Service Description: Service that implements Google Cloud Speech Adaptation API.</p>
-<p> <p>Sample for AdaptationClient:</p>
- <pre class="prettyprint lang-java"><code>
+      <p> <p><h2> AdaptationClient </h2></p>
+      <p> <p>Service Description: Service that implements Google Cloud Speech Adaptation API.</p>
+      <p> <p>Sample for AdaptationClient:</p>
+      <pre class="prettyprint lang-java"><code>
  try (AdaptationClient adaptationClient = AdaptationClient.create()) {
    LocationName parent = LocationName.of("[PROJECT]", "[LOCATION]");
    PhraseSet phraseSet = PhraseSet.newBuilder().build();
@@ -52,10 +52,10 @@
    PhraseSet response = adaptationClient.createPhraseSet(parent, phraseSet, phraseSetId);
  }
  </code></pre></section>
-      <h3><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.html">com.google.cloud.speech.v1p1beta1.stub</a></h3>
-      <section></section>
-</article>
-    </div>
-    {% endverbatim %}
-  </body>
+    <h2><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.html">com.google.cloud.speech.v1p1beta1.stub</a></h2>
+    <section></section>
+  </article>
+</div>
+{% endverbatim %}
+</body>
 </html>

--- a/third_party/docfx/templates/devsite/ManagedReference.common.js
+++ b/third_party/docfx/templates/devsite/ManagedReference.common.js
@@ -18,6 +18,12 @@ exports.transform = function (model) {
   if (model.type) {
     switch (model.type.toLowerCase()) {
       case 'overview':
+        // For Java, use special template to ensure indentation is correct on righthand nav
+        if(model.langs[0] === "java" && model.children) {
+          model.isJavaOverview = true;
+          groupChildren(model, namespaceCategory);
+          break;
+        }
       case 'package':
       case 'namespace':
         model.isNamespace = true;
@@ -265,7 +271,7 @@ function handleItem(vm, gitContribute, gitUrlPattern) {
   function shouldHideTitleType(vm) {
     var type = vm.type.toLowerCase();
     return ((type === 'namespace' && langs.length == 1 && (langs[0] === 'objectivec' || langs[0] === 'java' || langs[0] === 'c'))
-      || ((type === 'class' || type === 'enum') && langs.length == 1 && langs[0] === 'c'));
+        || ((type === 'class' || type === 'enum') && langs.length == 1 && langs[0] === 'c'));
   }
 
   function shouldHideSubtitle(vm) {
@@ -284,7 +290,7 @@ function handleItem(vm, gitContribute, gitUrlPattern) {
     return array;
   }
 
-  
+
   // handles where syntax return/parameters type doesn't include specName but includes uid
   if (vm.syntax && langs[0]) {
 
@@ -333,7 +339,7 @@ function handleItem(vm, gitContribute, gitUrlPattern) {
   }
 
   if (vm.javaType) {
-    // Resetting 'type' from added field 'javaType' field here 
+    // Resetting 'type' from added field 'javaType' field here
     // because docfx cannot process custom types while using ManagedReference.
     // This allows Java to use custom types without rewriting for UniversalReference
     vm.type = vm.javaType;

--- a/third_party/docfx/templates/devsite/ManagedReference.html.primary.tmpl
+++ b/third_party/docfx/templates/devsite/ManagedReference.html.primary.tmpl
@@ -11,3 +11,6 @@
 {{#isEnum}}
   {{>partials/enum}}
 {{/isEnum}}
+{{#isJavaOverview}}
+  {{>partials/javaOverview}}
+{{/isJavaOverview}}

--- a/third_party/docfx/templates/devsite/partials/javaOverview.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/javaOverview.tmpl.partial
@@ -1,0 +1,19 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+{{>partials/disclaimer}}
+{{#summary}}
+<div class="markdown level0 summary">{{{summary}}}</div>
+{{/summary}}
+{{#conceptual}}
+<div class="markdown level0 conceptual">{{{conceptual}}}</div>
+{{/conceptual}}
+{{#remarks}}
+<div class="markdown level0 remarks">{{{remarks}}}</div>
+{{/remarks}}
+{{#children}}
+  <h2 id="{{id}}">{{>partials/namespaceSubtitle}}</h2>
+  {{#children}}
+    <h2><xref uid="{{uid}}" altProperty="fullName" displayProperty="name"/>{{#deprecated}} (deprecated){{/deprecated}}</h2>
+    <section>{{{summary}}}</section>
+  {{/children}}
+{{/children}}


### PR DESCRIPTION
Fix for https://github.com/googleapis/doc-pipeline/issues/436

parent bug: b/278903399
Corresponds to [R9] Confusing ‘On This Page’ Indentation on cloud-java-rad-refactor and slide 20 on cloud-java-rad-visual-review.

For example on: https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/overview

APIKeysClient is outdented even though it is a child of com.google.api.apikeys.v2.

This will be a two-part fix, with this being the template change, and https://github.com/googleapis/java-docfx-doclet/issues/178 being the doclet change

This pulls in updated golden files (thanks Dan!) from: https://github.com/googleapis/doc-pipeline/pull/464