### PR TITLE
fix: add type alias header cpp

### DIFF
--- a/testdata/goldens/cpp/classgoogle_1_1cloud_1_1ConnectionOptions.html
+++ b/testdata/goldens/cpp/classgoogle_1_1cloud_1_1ConnectionOptions.html
@@ -717,7 +717,8 @@ Not intended for applications to use. There is no alternative implemented or pla
       </tr>
     </tbody>
   </table>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="classgoogle_1_1cloud_1_1ConnectionOptions_1a041758d537570967fa7fcc73e314489f" data-uid="classgoogle_1_1cloud_1_1ConnectionOptions_1a041758d537570967fa7fcc73e314489f" class="notranslate">BackgroundThreadsFactory</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>::google::cloud::BackgroundThreadsFactory</code>

--- a/testdata/goldens/cpp/classgoogle_1_1cloud_1_1LogSink.html
+++ b/testdata/goldens/cpp/classgoogle_1_1cloud_1_1LogSink.html
@@ -406,7 +406,8 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="classgoogle_1_1cloud_1_1LogSink_1af480aa59f84e27c56949904244b44984" data-uid="classgoogle_1_1cloud_1_1LogSink_1af480aa59f84e27c56949904244b44984" class="notranslate">BackendId</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>long</code>

--- a/testdata/goldens/cpp/classgoogle_1_1cloud_1_1StatusOr.html
+++ b/testdata/goldens/cpp/classgoogle_1_1cloud_1_1StatusOr.html
@@ -631,7 +631,8 @@ StatusOr&lt;Bar&gt; MakeBar() {
       </tr>
     </tbody>
   </table>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="classgoogle_1_1cloud_1_1StatusOr_1a2f3f95ac87322b5e6593c61de407d045" data-uid="classgoogle_1_1cloud_1_1StatusOr_1a2f3f95ac87322b5e6593c61de407d045" class="notranslate">value_type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>T</code>

--- a/testdata/goldens/cpp/classgoogle_1_1cloud_1_1StreamRange.html
+++ b/testdata/goldens/cpp/classgoogle_1_1cloud_1_1StreamRange.html
@@ -194,7 +194,8 @@ To construct a <a class="xref" href="classgoogle_1_1cloud_1_1StreamRange.html"><
       </tr>
     </tbody>
   </table>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="classgoogle_1_1cloud_1_1StreamRange_1a717e032ce46abfa423f908143d608c71" data-uid="classgoogle_1_1cloud_1_1StreamRange_1a717e032ce46abfa423f908143d608c71" class="notranslate">value_type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>StatusOr&lt; T &gt;</code>

--- a/testdata/goldens/cpp/classgoogle_1_1cloud_1_1StreamRange_1_1IteratorImpl.html
+++ b/testdata/goldens/cpp/classgoogle_1_1cloud_1_1StreamRange_1_1IteratorImpl.html
@@ -138,7 +138,8 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="classgoogle_1_1cloud_1_1StreamRange_1_1IteratorImpl_1a736a31477f42f53e47ecc79c2e1c7a49" data-uid="classgoogle_1_1cloud_1_1StreamRange_1_1IteratorImpl_1a736a31477f42f53e47ecc79c2e1c7a49" class="notranslate">iterator_category</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::input_iterator_tag</code>

--- a/testdata/goldens/cpp/classgoogle_1_1cloud_1_1future.html
+++ b/testdata/goldens/cpp/classgoogle_1_1cloud_1_1future.html
@@ -203,7 +203,8 @@ This operation invalidates the future, subsequent calls will fail, the applicati
       </tr>
     </tbody>
   </table>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="classgoogle_1_1cloud_1_1future_1ad7a72b78c2561600a88b30c52a2764eb" data-uid="classgoogle_1_1cloud_1_1future_1ad7a72b78c2561600a88b30c52a2764eb" class="notranslate">shared_state_type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>typename internal::future_base&lt; T &gt;::shared_state_type</code>

--- a/testdata/goldens/cpp/classgoogle_1_1cloud_1_1future_3_01void_01_4.html
+++ b/testdata/goldens/cpp/classgoogle_1_1cloud_1_1future_3_01void_01_4.html
@@ -190,7 +190,8 @@ The technical specification requires this to be a <code>noexcept</code> construc
       </tr>
     </tbody>
   </table>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="classgoogle_1_1cloud_1_1future_3_01void_01_4_1a49ddd3b209c866c3c83b6feb2e957aaa" data-uid="classgoogle_1_1cloud_1_1future_3_01void_01_4_1a49ddd3b209c866c3c83b6feb2e957aaa" class="notranslate">shared_state_type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>typename internal::future_base&lt; void &gt;::shared_state_type</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1AccessTokenLifetimeOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1AccessTokenLifetimeOption.html
@@ -13,7 +13,8 @@
   
   <div class="markdown level0 summary"><p>Configure the access token lifetime. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1AccessTokenLifetimeOption_1ad6b8a4672f1c196926849229f62d0de2" data-uid="structgoogle_1_1cloud_1_1AccessTokenLifetimeOption_1ad6b8a4672f1c196926849229f62d0de2" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::chrono::seconds</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1AuthorityOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1AuthorityOption.html
@@ -17,7 +17,8 @@
 <p>For REST-based services using HTTP/1.1 or HTTP/1.0 this is the <code>Host</code> header.</p>
 <p>Setting this option to the empty string has no effect, i.e., no headers are set. This can be useful if you are not using Google&#39;s production environment. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1AuthorityOption_1a2a43afe80294667d13ad814168bb233c" data-uid="structgoogle_1_1cloud_1_1AuthorityOption_1a2a43afe80294667d13ad814168bb233c" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::string</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1CARootsFilePathOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1CARootsFilePathOption.html
@@ -28,7 +28,8 @@ CA certificates can be revoked or expire, plan for updates in your deployment.
 <h6 id="see-also">See Also</h6>
 <p><a href="https://en.wikipedia.org/wiki/Certificate_authority">https://en.wikipedia.org/wiki/Certificate_authority</a> for a general introduction to SSL certificate authorities. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1CARootsFilePathOption_1a3bd9708c3fcb44760a8fb3d1ecbf131a" data-uid="structgoogle_1_1cloud_1_1CARootsFilePathOption_1a3bd9708c3fcb44760a8fb3d1ecbf131a" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::string</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1DelegatesOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1DelegatesOption.html
@@ -13,7 +13,8 @@
   
   <div class="markdown level0 summary"><p>Configure the delegates for <a class="xref" href="namespacegoogle_1_1cloud.html"><code>MakeImpersonateServiceAccountCredentials()</code></a></p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1DelegatesOption_1a6cc48715b5f857de1ab3c7d4a49918c6" data-uid="structgoogle_1_1cloud_1_1DelegatesOption_1a6cc48715b5f857de1ab3c7d4a49918c6" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::vector&lt; std::string &gt;</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1EndpointOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1EndpointOption.html
@@ -15,7 +15,8 @@
 </div>
   <div class="markdown level0 conceptual"><p>In almost all cases a suitable default will be chosen automatically. Applications may need to be changed to (1) test against a fake or simulator, or (2) use a beta or EAP version of the service. When using a beta or EAP version of the service, the <a class="xref" href="structgoogle_1_1cloud_1_1AuthorityOption.html">AuthorityOption</a> should also be set to the usual hostname of the service. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1EndpointOption_1a61a6cbac4806836ddb5bda2040dba797" data-uid="structgoogle_1_1cloud_1_1EndpointOption_1a61a6cbac4806836ddb5bda2040dba797" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::string</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcBackgroundThreadPoolSizeOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcBackgroundThreadPoolSizeOption.html
@@ -18,7 +18,8 @@
 <a class="xref" href="structgoogle_1_1cloud_1_1GrpcBackgroundThreadPoolSizeOption.html"><code>GrpcBackgroundThreadPoolSizeOption</code></a>, <a class="xref" href="structgoogle_1_1cloud_1_1GrpcCompletionQueueOption.html"><code>GrpcCompletionQueueOption</code></a>, and <a class="xref" href="structgoogle_1_1cloud_1_1GrpcBackgroundThreadsFactoryOption.html"><code>GrpcBackgroundThreadsFactoryOption</code></a> are mutually exclusive. This option will be ignored if either <a class="xref" href="structgoogle_1_1cloud_1_1GrpcCompletionQueueOption.html"><code>GrpcCompletionQueueOption</code></a> or <a class="xref" href="structgoogle_1_1cloud_1_1GrpcBackgroundThreadsFactoryOption.html"><code>GrpcBackgroundThreadsFactoryOption</code></a> are set. 
 </aside>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1GrpcBackgroundThreadPoolSizeOption_1a1054cdb1003689157d327581731f7bde" data-uid="structgoogle_1_1cloud_1_1GrpcBackgroundThreadPoolSizeOption_1a1054cdb1003689157d327581731f7bde" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::size_t</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcBackgroundThreadsFactoryOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcBackgroundThreadsFactoryOption.html
@@ -19,7 +19,8 @@
 <a class="xref" href="structgoogle_1_1cloud_1_1GrpcBackgroundThreadPoolSizeOption.html"><code>GrpcBackgroundThreadPoolSizeOption</code></a>, <a class="xref" href="structgoogle_1_1cloud_1_1GrpcCompletionQueueOption.html"><code>GrpcCompletionQueueOption</code></a>, and <a class="xref" href="structgoogle_1_1cloud_1_1GrpcBackgroundThreadsFactoryOption.html"><code>GrpcBackgroundThreadsFactoryOption</code></a> are mutually exclusive. This option will be ignored if <a class="xref" href="structgoogle_1_1cloud_1_1GrpcCompletionQueueOption.html"><code>GrpcCompletionQueueOption</code></a> is set. 
 </aside>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1GrpcBackgroundThreadsFactoryOption_1a65ea53b32b35f991ce3d0af6ee4faa4c" data-uid="structgoogle_1_1cloud_1_1GrpcBackgroundThreadsFactoryOption_1a65ea53b32b35f991ce3d0af6ee4faa4c" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>BackgroundThreadsFactory</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcChannelArgumentsNativeOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcChannelArgumentsNativeOption.html
@@ -23,7 +23,8 @@ Our library will always start with the native object, then add in the channel ar
 <h6 id="see-also-1">See Also</h6>
 <p><a href="https://grpc.github.io/grpc/core/group__grpc__arg__keys.html">https://grpc.github.io/grpc/core/group__grpc__arg__keys.html</a></p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1GrpcChannelArgumentsNativeOption_1afb9fa0fc355222b6a827e53e12d91b24" data-uid="structgoogle_1_1cloud_1_1GrpcChannelArgumentsNativeOption_1afb9fa0fc355222b6a827e53e12d91b24" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>grpc::ChannelArguments</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcChannelArgumentsOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcChannelArgumentsOption.html
@@ -23,7 +23,8 @@ Our library will always start with the native object from <a class="xref" href="
 <h6 id="see-also-1">See Also</h6>
 <p><a href="https://grpc.github.io/grpc/core/group__grpc__arg__keys.html">https://grpc.github.io/grpc/core/group__grpc__arg__keys.html</a></p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1GrpcChannelArgumentsOption_1afb6d7bd99eda67d1c6b208a7e92af139" data-uid="structgoogle_1_1cloud_1_1GrpcChannelArgumentsOption_1afb6d7bd99eda67d1c6b208a7e92af139" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::map&lt; std::string, std::string &gt;</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcCompletionQueueOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcCompletionQueueOption.html
@@ -18,7 +18,8 @@
 <a class="xref" href="structgoogle_1_1cloud_1_1GrpcBackgroundThreadPoolSizeOption.html"><code>GrpcBackgroundThreadPoolSizeOption</code></a>, <a class="xref" href="structgoogle_1_1cloud_1_1GrpcCompletionQueueOption.html"><code>GrpcCompletionQueueOption</code></a>, and <a class="xref" href="structgoogle_1_1cloud_1_1GrpcBackgroundThreadsFactoryOption.html"><code>GrpcBackgroundThreadsFactoryOption</code></a> are mutually exclusive. 
 </aside>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1GrpcCompletionQueueOption_1a4273ed18516746cf0c0e1e1731db266a" data-uid="structgoogle_1_1cloud_1_1GrpcCompletionQueueOption_1a4273ed18516746cf0c0e1e1731db266a" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>CompletionQueue</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcCredentialOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcCredentialOption.html
@@ -13,7 +13,8 @@
   
   <div class="markdown level0 summary"><p>The gRPC credentials used by clients configured with this object. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1GrpcCredentialOption_1abbd8711da4d2b6934f853ab8054c901a" data-uid="structgoogle_1_1cloud_1_1GrpcCredentialOption_1abbd8711da4d2b6934f853ab8054c901a" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::shared_ptr&lt; grpc::ChannelCredentials &gt;</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcNumChannelsOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcNumChannelsOption.html
@@ -26,7 +26,8 @@ This option only applies when passed to the following functions:
 - <code>storage_experimental::DefaultGrpcClient()</code>
 </aside>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1GrpcNumChannelsOption_1a4e2c298b9310373e19a5c76e8b7473e6" data-uid="structgoogle_1_1cloud_1_1GrpcNumChannelsOption_1a4e2c298b9310373e19a5c76e8b7473e6" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>int</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcTracingOptionsOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1GrpcTracingOptionsOption.html
@@ -13,7 +13,8 @@
   
   <div class="markdown level0 summary"><p>The <a class="xref" href="classgoogle_1_1cloud_1_1TracingOptions.html"><code>TracingOptions</code></a> to use when printing grpc protocol buffer messages. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1GrpcTracingOptionsOption_1af678ec85d9990e384f0be0b7a639d624" data-uid="structgoogle_1_1cloud_1_1GrpcTracingOptionsOption_1af678ec85d9990e384f0be0b7a639d624" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>TracingOptions</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1QuotaUserOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1QuotaUserOption.html
@@ -15,7 +15,8 @@
 </div>
   <div class="markdown level0 conceptual"><p>A pseudo user identifier for charging per-user quotas. If not specified, the authenticated principal is used. If there is no authenticated principal, the client IP address will be used. When specified, a valid API key with service restrictions must be used to identify the quota project. Otherwise, this parameter is ignored. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1QuotaUserOption_1a65e6f5636acef31c70ed76258c051582" data-uid="structgoogle_1_1cloud_1_1QuotaUserOption_1a65e6f5636acef31c70ed76258c051582" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::string</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1RestTracingOptionsOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1RestTracingOptionsOption.html
@@ -13,7 +13,8 @@
   
   <div class="markdown level0 summary"><p>The <a class="xref" href="classgoogle_1_1cloud_1_1TracingOptions.html"><code>TracingOptions</code></a> to use when printing REST transport http messages. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1RestTracingOptionsOption_1a8d6d51b6e9be89779d1053016b2a2802" data-uid="structgoogle_1_1cloud_1_1RestTracingOptionsOption_1a8d6d51b6e9be89779d1053016b2a2802" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>TracingOptions</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1ScopesOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1ScopesOption.html
@@ -13,7 +13,8 @@
   
   <div class="markdown level0 summary"><p>Configure the scopes for <a class="xref" href="namespacegoogle_1_1cloud.html"><code>MakeImpersonateServiceAccountCredentials()</code></a></p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1ScopesOption_1a95557b309f247c5c848d0392338119ae" data-uid="structgoogle_1_1cloud_1_1ScopesOption_1a95557b309f247c5c848d0392338119ae" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::vector&lt; std::string &gt;</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1ServerTimeoutOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1ServerTimeoutOption.html
@@ -15,7 +15,8 @@
 </div>
   <div class="markdown level0 conceptual"><p>This system param only applies to REST APIs for which client-side timeout is not applicable. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1ServerTimeoutOption_1adca01c4480f74545b05eb1038f9a9a56" data-uid="structgoogle_1_1cloud_1_1ServerTimeoutOption_1adca01c4480f74545b05eb1038f9a9a56" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::chrono::milliseconds</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1TracingComponentsOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1TracingComponentsOption.html
@@ -19,7 +19,8 @@
 <li>rpc-streams </li>
 </ul>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1TracingComponentsOption_1a14eb9d2fb091bb17e433d7325326f78b" data-uid="structgoogle_1_1cloud_1_1TracingComponentsOption_1a14eb9d2fb091bb17e433d7325326f78b" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::set&lt; std::string &gt;</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1UnifiedCredentialsOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1UnifiedCredentialsOption.html
@@ -13,7 +13,8 @@
   
   <div class="markdown level0 summary"><p>A wrapper to store credentials into an options. </p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1UnifiedCredentialsOption_1affa4ac9e72fe5624e15d17e507177d2b" data-uid="structgoogle_1_1cloud_1_1UnifiedCredentialsOption_1affa4ac9e72fe5624e15d17e507177d2b" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::shared_ptr&lt; Credentials &gt;</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1UserAgentProductsOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1UserAgentProductsOption.html
@@ -17,7 +17,8 @@
 <h6 id="see-also">See Also</h6>
 <p><a href="https://tools.ietf.org/html/rfc7231#section-5.5.3">https://tools.ietf.org/html/rfc7231#section-5.5.3</a></p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1UserAgentProductsOption_1acbbd25eda33665932bf5561aae9682e3" data-uid="structgoogle_1_1cloud_1_1UserAgentProductsOption_1acbbd25eda33665932bf5561aae9682e3" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::vector&lt; std::string &gt;</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1UserIpOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1UserIpOption.html
@@ -20,7 +20,8 @@
 prefer using <code>google::cloud::QuotaUser</code>.
 </aside>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1UserIpOption_1af69a552534f64cd51243a002e1dd6488" data-uid="structgoogle_1_1cloud_1_1UserIpOption_1af69a552534f64cd51243a002e1dd6488" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::string</code>

--- a/testdata/goldens/cpp/structgoogle_1_1cloud_1_1UserProjectOption.html
+++ b/testdata/goldens/cpp/structgoogle_1_1cloud_1_1UserProjectOption.html
@@ -19,7 +19,8 @@
 <h6 id="see-also-1">See Also</h6>
 <p><a href="https://cloud.google.com/apis/docs/system-parameters">https://cloud.google.com/apis/docs/system-parameters</a></p>
 </div>
-  <h2 id="typealiases"></h2>
+  <h2 id="typealiases">Type Aliases
+  </h2>
   <h3 id="structgoogle_1_1cloud_1_1UserProjectOption_1a05738e758fa2b69dd115a85369c618f8" data-uid="structgoogle_1_1cloud_1_1UserProjectOption_1a05738e758fa2b69dd115a85369c618f8" class="notranslate">Type</h3>
   <div class="level1 summary">
     <strong>Alias Of</strong>: <code>std::string</code>

--- a/third_party/docfx/templates/devsite/partials/classSubtitle.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/classSubtitle.tmpl.partial
@@ -47,3 +47,6 @@
 {{#inConst}}
 {{__global.constsInSubtitle}}
 {{/inConst}}
+{{#inTypeAlias}}
+{{__global.typeAliasesInSubtitle}}
+{{/inTypeAlias}}


### PR DESCRIPTION
This was omitted in class pages and only added in namespace files.

Verified with the staged page on https://cloud.google.com/cpp/docs/reference/common/latest/classgoogle_1_1cloud_1_1StreamRange equivalent.

Fixes https://github.com/googleapis/google-cloud-cpp/issues/11683.