### PR TITLE
fix: support new tar format

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -134,7 +134,9 @@ def setup_bucket_docfx(
     # If so, only decompress things into obj/*
     tar_file = tarfile.open(tar_filename)
     for tarinfo in tar_file:
-        if tarinfo.isdir() and tarinfo.name == "./api":
+        if (
+            tarinfo.isdir() and tarinfo.name == "./api"
+        ) or tarinfo.name.startswith("api/"):
             decompress_path = tmp_path.joinpath("obj")
             break
     tar.decompress(tar_filename, decompress_path)


### PR DESCRIPTION
Tar files could contain contents in a subdirectory but not in directories. This was causing an error with .NET's new help tarball.

Verified that the tarball was fixed based on the this PR's commit on https://source.cloud.google.com/results/invocations/5666e3a3-e92a-467b-84a0-514afa45d2ea/targets/cloud-devrel%2Fclient-libraries%2Fdoc-pipeline%2Fgenerate%2Fgenerate-prod/log

Fixes #535. Towards b/298290402.