### PR TITLE
chore: configure Trampoline to forward UPDATE_GOLDENS environment variable

### DIFF
--- a/.trampolinerc
+++ b/.trampolinerc
@@ -27,6 +27,7 @@ pass_down_envvars+=(
     "INPUT"              # For specifying local input source.
     "BLOB_TO_DELETE"     # For delete-blob.
     "KOKORO_BUILD_ARTIFACTS_SUBDIR" # For job type detection.
+    "UPDATE_GOLDENS"     # Update golden test files.
 )
 
 # Prevent unintentional override on the default image.


### PR DESCRIPTION
Otherwise, if you try to update the goldens via Docker, it won't work.

Fixes #457.