### PR TITLE
feat: add template for enum table for Python

### DIFF
--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
@@ -34,15 +34,15 @@ The Read API can be used to read data from BigQuery.</p>
       </tr>
       <tr>
         <td><code>google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient</code></td>
-        <td>The default value if the employment typeisn't specified.</td>
+        <td>The default value if the employment type isn't specified.</td>
       </tr>
       <tr>
         <td><code>google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient</code></td>
-        <td>The job requires working a number of hoursthat constitute full time employment, typically40 or more hours per week.</td>
+        <td>The job requires working a number of hours that constitute full time employment, typically 40 or more hours per week.</td>
       </tr>
       <tr>
         <td><code>google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient</code></td>
-        <td>The job entails working fewer hours than afull time job, typically less than 40 hours aweek.</td>
+        <td>The job entails working fewer hours than a full time job, typically less than 40 hours aweek.</td>
       </tr>
     </tbody>
   </table>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
@@ -23,6 +23,29 @@ The Read API can be used to read data from BigQuery.</p>
       <span> &gt; </span>
       <span class="xref">BigQueryReadClient</span>
   </div>
+  <table class="responsive">
+    <tbody>
+      <tr>
+        <th colspan="2"><h2>Enums</h2></th>
+      </tr>
+      <tr>
+        <td><strong>Name</strong></td>
+        <td><strong>Description</strong></td>
+      </tr>
+      <tr>
+        <td><code>google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient</code></td>
+        <td>The default value if the employment typeisn't specified.</td>
+      </tr>
+      <tr>
+        <td><code>google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient</code></td>
+        <td>The job requires working a number of hoursthat constitute full time employment, typically40 or more hours per week.</td>
+      </tr>
+      <tr>
+        <td><code>google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient</code></td>
+        <td>The job entails working fewer hours than afull time job, typically less than 40 hours aweek.</td>
+      </tr>
+    </tbody>
+  </table>
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_transport" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.transport" class="notranslate">transport</h3>

--- a/testdata/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.yml
+++ b/testdata/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.yml
@@ -31,6 +31,15 @@ items:
   - google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.transport
   class: google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient
   fullName: google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient
+  enum:
+  - description: The default value if the employment typeisn't specified.
+    var_name: EMPLOYMENT_TYPE_UNSPECIFIED
+  - description: The job requires working a number of hoursthat constitute full time
+      employment, typically40 or more hours per week.
+    var_name: FULL_TIME
+  - description: The job entails working fewer hours than afull time job, typically
+      less than 40 hours aweek.
+    var_name: PART_TIME
   inheritance:
   - type: builtins.object
   langs:

--- a/testdata/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.yml
+++ b/testdata/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.yml
@@ -32,12 +32,12 @@ items:
   class: google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient
   fullName: google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient
   enum:
-  - description: The default value if the employment typeisn't specified.
+  - description: The default value if the employment type isn't specified.
     var_name: EMPLOYMENT_TYPE_UNSPECIFIED
-  - description: The job requires working a number of hoursthat constitute full time
-      employment, typically40 or more hours per week.
+  - description: The job requires working a number of hours that constitute full time
+      employment, typically 40 or more hours per week.
     var_name: FULL_TIME
-  - description: The job entails working fewer hours than afull time job, typically
+  - description: The job entails working fewer hours than a full time job, typically
       less than 40 hours aweek.
     var_name: PART_TIME
   inheritance:

--- a/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
@@ -186,3 +186,24 @@
 {{#example}}
 {{{.}}}
 {{/example}}
+{{#enum.0}}
+<table class="responsive">
+  <tbody>
+    <tr>
+      <th colspan=2><h2>{{__global.enum}}{{#enum.1}}s{{/enum.1}}</h2></th>
+    </tr>
+    <tr>
+      <td><strong>{{__global.name}}</strong></td>
+      <td><strong>{{__global.description}}</strong></td>
+    </tr>
+{{/enum.0}}
+{{#enum}}
+    <tr>
+      <td><code>{{{id}}}</code></td>
+      <td>{{{description}}}</td>
+    </tr>
+{{/enum}}
+{{#enum.0}}
+  </tbody>
+</table>
+{{/enum.0}}

--- a/third_party/docfx/templates/devsite/token.json
+++ b/third_party/docfx/templates/devsite/token.json
@@ -70,5 +70,6 @@
   "important": "Important",
   "caution": "Caution",
   "attribute": "Attribute",
-  "properties": "Properties"
+  "properties": "Properties",
+  "enum": "Enum"
 }


### PR DESCRIPTION
Using the pre-existing enum format for UniversalRef, adding a template for it in the Class headers. I've verified that enum entries only exist in the header and not in the main class, but if I find examples I'll add it in to main class as well.

For the enums that are concerned as of right now, they only appear as the class header (since it's enum classes).

See staged example on b/338431108.

Unblocks https://github.com/googleapis/sphinx-docfx-yaml/pull/376.
Towards b/338431108.