### PR TITLE
test: update test to allow run in parallel

### DIFF
--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -38,6 +38,17 @@ _UUID = str(datetime.datetime.now(tz=datetime.timezone.utc).timestamp()).replace
 _UNIQUE_YAML_BLOB_NAME = f"docfx-go-cloud.google.com/go/storage-v1.40.0+{_UUID}.tar.gz"
 _UNIQUE_HTML_BLOB_NAME = f"go-cloud.google.com/go/storage-v1.40.0+{_UUID}.tar.gz"
 
+_XREF_BLOBS = (
+    "xrefs/go-unused-v0.0.1.tar.gz.yml",
+    "xrefs/dotnet-my-pkg-1.0.0.tar.gz.yml",
+    "xrefs/dotnet-my-pkg-v1.1.0.tar.gz.yml",
+    "xrefs/dotnet-my-pkg-2.0.0-SNAPSHOT.tar.gz.yml",
+    "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml",
+    "xrefs/dotnet-my-pkg-unused-3.0.0.tar.gz.yml",
+    "xrefs/dotnet-v-pkg-v3.0.0.tar.gz.yml",
+    "xrefs/dotnet-v-pkg-v4.0.0.tar.gz.yml",
+)
+
 
 def _add_uuid_to_metadata(cwd, metadata_name) -> None:
     metadata_path = cwd.joinpath(metadata_name)
@@ -131,6 +142,7 @@ def setup_testdata(cwd, storage_client, test_bucket):
         for blob in blobs
         if (datetime.datetime.now(tz=datetime.timezone.utc) - blob.time_created).days
         > 0
+        and blob.name not in _XREF_BLOBS
     ]
     for blob_to_remove in blobs_to_remove:
         try:
@@ -402,17 +414,7 @@ def xref_test_blobs():
     test_bucket, storage_client = init_test()
     bucket = storage_client.get_bucket(test_bucket)
 
-    blobs_to_create = [
-        "xrefs/go-unused-v0.0.1.tar.gz.yml",
-        "xrefs/dotnet-my-pkg-1.0.0.tar.gz.yml",
-        "xrefs/dotnet-my-pkg-v1.1.0.tar.gz.yml",
-        "xrefs/dotnet-my-pkg-2.0.0-SNAPSHOT.tar.gz.yml",
-        "xrefs/dotnet-my-pkg-2.0.0.tar.gz.yml",
-        "xrefs/dotnet-my-pkg-unused-3.0.0.tar.gz.yml",
-        "xrefs/dotnet-v-pkg-v3.0.0.tar.gz.yml",
-        "xrefs/dotnet-v-pkg-v4.0.0.tar.gz.yml",
-    ]
-    for b in blobs_to_create:
+    for b in _XREF_BLOBS:
         blob = bucket.blob(b)
         if not blob.exists():
             blob.upload_from_string("unused")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -402,11 +402,6 @@ def xref_test_blobs():
     test_bucket, storage_client = init_test()
     bucket = storage_client.get_bucket(test_bucket)
 
-    # Remove all existing test xref blobs.
-    blobs_to_delete = bucket.list_blobs(prefix="xrefs/")
-    for blob in blobs_to_delete:
-        blob.delete()
-
     blobs_to_create = [
         "xrefs/go-unused-v0.0.1.tar.gz.yml",
         "xrefs/dotnet-my-pkg-1.0.0.tar.gz.yml",

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -125,7 +125,11 @@ def clean_up_bucket(storage_client, test_bucket):
     blobs = list(storage_client.list_blobs(test_bucket))
     for blob in blobs:
         # If blob starts with any of the prefixes to delete, mark for deletion.
-        if not all(blob.name.startswith(prefix) for prefix in _TEST_BLOB_PREFIXES):
+        if (
+            datetime.datetime.now(tz=datetime.timezone.utc) - blob.time_created
+        ).days > 0 and not all(
+            blob.name.startswith(prefix) for prefix in _TEST_BLOB_PREFIXES
+        ):
             continue
         # If blob was used in this current testing session, mark for deletion.
         if blob.name not in _UNIQUE_BLOBS_WITH_UUID:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -32,7 +32,9 @@ from docpipeline import generate, local_generate
 
 
 # Unique identifier for runnig parallel tests.
-_UUID = str(datetime.datetime.now(tz=datetime.timezone.utc)).replace(".", "")
+_UUID = str(datetime.datetime.now(tz=datetime.timezone.utc).timestamp()).replace(
+    ".", ""
+)
 _UNIQUE_YAML_BLOB_NAME = f"docfx-go-cloud.google.com/go/storage-v1.40.0+{_UUID}.tar.gz"
 _UNIQUE_HTML_BLOB_NAME = f"go-cloud.google.com/go/storage-v1.40.0+{_UUID}.tar.gz"
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -127,13 +127,11 @@ def clean_up_bucket(storage_client, test_bucket):
         # If blob starts with any of the prefixes to delete, mark for deletion.
         if (
             datetime.datetime.now(tz=datetime.timezone.utc) - blob.time_created
-        ).days > 0 and not all(
+        ).days == 0 or not all(
             blob.name.startswith(prefix) for prefix in _TEST_BLOB_PREFIXES
         ):
             continue
-        # If blob was used in this current testing session, mark for deletion.
-        if blob.name not in _UNIQUE_BLOBS_WITH_UUID:
-            continue
+
         try:
             blob.delete()
         except Exception:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -75,8 +75,7 @@ _XREF_BLOBS = (
 
 def _add_uuid_to_metadata(cwd, metadata_name) -> None:
     metadata_path = cwd.joinpath(metadata_name)
-    metadata = metadata_pb2.Metadata()
-    text_format.Merge(metadata_path.read_text(), metadata)
+    metadata = text_format.ParseLines(metadata_path, metadata_pb2.Metadata())
     metadata.version += f"+{_UUID}"
     with open(metadata_path, "w") as f:
         f.write(str(metadata))

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -31,7 +31,7 @@ import pytest
 from docpipeline import generate, local_generate
 
 
-# Unique identifier for runnig parallel tests.
+# Unique identifier for running tests in parallel.
 _UUID = str(datetime.datetime.now(tz=datetime.timezone.utc).timestamp()).replace(
     ".", ""
 )
@@ -97,7 +97,7 @@ def init_test():
     return test_bucket, storage_client
 
 
-def cleanup_bucket(storage_client, test_bucket):
+def clean_up_bucket(storage_client, test_bucket):
     bucket = storage_client.get_bucket(test_bucket)
     blobs_to_delete = [
         f"docfx-go-cloud.google.com/go/storage-v1.41.0+{_UUID}.tar.gz",

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -407,9 +407,6 @@ def test_generate(yaml_dir, tmpdir):
     t10 = html_blob.updated
     assert t9 != t10, "old version was not updated after build_new_docs"
 
-    # Perform cleanup on used blobs.
-    clean_up_bucket(storage_client, test_bucket)
-
 
 def test_local_generate(yaml_dir, tmpdir):
     # Test for local generation content

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -91,6 +91,7 @@ def cleanup_bucket(storage_client, test_bucket):
     blobs_to_delete = [
         f"docfx-go-cloud.google.com/go/storage-v1.41.0+{_UUID}.tar.gz",
         f"go-cloud.google.com/go/storage-v1.41.0+{_UUID}.tar.gz",
+        f"docfx-go-cloud.google.com/go/storage-v1.40.1+{_UUID}.tar.gz",
         f"go-cloud.google.com/go/storage-v1.40.1+{_UUID}.tar.gz",
         _UNIQUE_YAML_BLOB_NAME,
         _UNIQUE_HTML_BLOB_NAME,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -19,7 +19,6 @@ import pathlib
 import shutil
 import tempfile
 import unittest
-import uuid
 
 import docuploader.credentials
 from docuploader import shell, tar
@@ -33,7 +32,7 @@ from docpipeline import generate, local_generate
 
 
 # Unique identifier for runnig parallel tests.
-_UUID = str(uuid.uuid4()).replace("-", "")
+_UUID = str(datetime.datetime.now(tz=datetime.timezone.utc)).replace(".", "")
 _UNIQUE_YAML_BLOB_NAME = f"docfx-go-cloud.google.com/go/storage-v1.40.0+{_UUID}.tar.gz"
 _UNIQUE_HTML_BLOB_NAME = f"go-cloud.google.com/go/storage-v1.40.0+{_UUID}.tar.gz"
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -75,7 +75,8 @@ _XREF_BLOBS = (
 
 def _add_uuid_to_metadata(cwd, metadata_name) -> None:
     metadata_path = cwd.joinpath(metadata_name)
-    metadata = text_format.ParseLines(metadata_path, metadata_pb2.Metadata())
+    metadata = metadata_pb2.Metadata()
+    text_format.Merge(metadata_path.read_text(), metadata)
     metadata.version += f"+{_UUID}"
     with open(metadata_path, "w") as f:
         f.write(str(metadata))


### PR DESCRIPTION
Updating unit test to be able to run in parallel.

Previously, we simply checked that more blobs are created and deleted old ones - however, this caused a lot of issues when multiple presubmits are run at the same time.

Instead, changed to create fixed blobs (using metadata notion to work with multi-version and semver) and check for those specific blobs.

For xref blobs I've decided to try to keep them there, since `generate.get_xref` takes the entire bucket, adding unique identifiers for these blobs really doesn't make sense, and the point of the xref blobs is to test its content not to test that they get uploaded to the bucket, at least in this point.

Verified that the tests run by running several tests altogether with #645.

Fixes #368.