### PR TITLE
chore: update .NET goldens

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AnalyzeIamPolicyLongrunningRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AnalyzeIamPolicyLongrunningResponse</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AnalyzeIamPolicyRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -140,7 +140,7 @@ fully explored to answer the query.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AnalyzeIamPolicyResponse.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AnalyzeIamPolicyResponse</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -96,7 +96,7 @@ answer the query in the request.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -26,13 +26,13 @@ for more information.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">Asset</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -40,16 +40,16 @@ for more information.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -174,7 +174,7 @@ asset itself.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -199,7 +199,7 @@ for more information.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -255,7 +255,7 @@ for more information.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
@@ -19,22 +19,22 @@ public abstract class AssetServiceBase</code></pre>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AssetService.AssetServiceBase</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -82,7 +82,7 @@ which resources.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -134,7 +134,7 @@ request to help callers to map responses to requests.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -184,7 +184,7 @@ error.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -229,7 +229,7 @@ asset updates.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -273,7 +273,7 @@ asset updates.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.Protobuf.WellKnownTypes.Empty</span>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.Protobuf.WellKnownTypes.Empty</span>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -326,7 +326,7 @@ finishes within 5 minutes.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -370,7 +370,7 @@ finishes within 5 minutes.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -415,7 +415,7 @@ response.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsResponse.html">ListAssetsResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsResponse.html">ListAssetsResponse</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -459,7 +459,7 @@ response.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -506,7 +506,7 @@ otherwise the request will be rejected.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -553,7 +553,7 @@ otherwise the request will be rejected.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>
@@ -597,7 +597,7 @@ otherwise the request will be rejected.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>The response to send back to the client (wrapped by a task).</p>
 </td>
       </tr>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
@@ -18,7 +18,7 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span><span class="xref">Grpc.Core.ClientBase</span></span> <span> &gt; </span>
     <span><span class="xref">Grpc.Core.ClientBase</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html">AssetService.AssetServiceClient</a>&gt;</span> <span> &gt; </span>
     <span class="xref">AssetService.AssetServiceClient</span>
@@ -32,16 +32,16 @@
       <span class="xref">Grpc.Core.ClientBase.CallInvoker</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -226,12 +226,12 @@ which resources.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -326,12 +326,12 @@ which resources.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -440,12 +440,12 @@ request to help callers to map responses to requests.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -554,12 +554,12 @@ request to help callers to map responses to requests.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -664,12 +664,12 @@ error.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -774,12 +774,12 @@ error.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -874,12 +874,12 @@ asset updates.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -974,12 +974,12 @@ asset updates.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1096,12 +1096,12 @@ this client.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1194,12 +1194,12 @@ this client.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1310,12 +1310,12 @@ finishes within 5 minutes.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1426,12 +1426,12 @@ finishes within 5 minutes.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1524,12 +1524,12 @@ finishes within 5 minutes.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1622,12 +1622,12 @@ finishes within 5 minutes.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1722,12 +1722,12 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1822,12 +1822,12 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -1920,12 +1920,12 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -2018,12 +2018,12 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -2161,12 +2161,12 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -2265,12 +2265,12 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -2369,12 +2369,12 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -2473,12 +2473,12 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -2571,12 +2571,12 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>
@@ -2669,12 +2669,12 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>deadline</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.datetime">DateTime</a>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.DateTime</span>&gt;</code><br><p>An optional deadline for the call. The call will be cancelled if deadline is hit.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>An optional token for canceling the call.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>An optional token for canceling the call.</p>
 </td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AssetService</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">AssetServiceClient</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <div>
@@ -89,7 +89,7 @@ of 443.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -111,7 +111,7 @@ of 443.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1">IReadOnlyList</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">System.Collections.Generic.IReadOnlyList</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -250,7 +250,7 @@ which resources.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -280,7 +280,7 @@ which resources.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -295,7 +295,7 @@ which resources.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -399,7 +399,7 @@ request to help callers to map responses to requests.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -436,7 +436,7 @@ request to help callers to map responses to requests.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -451,7 +451,7 @@ request to help callers to map responses to requests.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -551,7 +551,7 @@ error.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -586,7 +586,7 @@ error.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -601,7 +601,7 @@ error.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -650,7 +650,7 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>The <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use while creating the client.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>The <span class="xref">System.Threading.CancellationToken</span> to use while creating the client.</p>
 </td>
       </tr>
     </tbody>
@@ -665,7 +665,7 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a>&gt;</code></td>
         <td><p>The task representing the created <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a>.</p>
 </td>
       </tr>
@@ -735,7 +735,7 @@ asset updates.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>parent</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the project/folder/organization where this feed
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the project/folder/organization where this feed
 should be created in. It can only be an organization number (such as
 &quot;organizations/123&quot;), a folder number (such as &quot;folders/123&quot;), a project ID
 (such as &quot;projects/my-project-id&quot;)&quot;, or a project number (such as
@@ -804,7 +804,7 @@ asset updates.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -834,7 +834,7 @@ asset updates.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -849,7 +849,7 @@ asset updates.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -874,7 +874,7 @@ asset updates.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>parent</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the project/folder/organization where this feed
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the project/folder/organization where this feed
 should be created in. It can only be an organization number (such as
 &quot;organizations/123&quot;), a folder number (such as &quot;folders/123&quot;), a project ID
 (such as &quot;projects/my-project-id&quot;)&quot;, or a project number (such as
@@ -898,7 +898,7 @@ should be created in. It can only be an organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -923,7 +923,7 @@ asset updates.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>parent</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the project/folder/organization where this feed
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the project/folder/organization where this feed
 should be created in. It can only be an organization number (such as
 &quot;organizations/123&quot;), a folder number (such as &quot;folders/123&quot;), a project ID
 (such as &quot;projects/my-project-id&quot;)&quot;, or a project number (such as
@@ -932,7 +932,7 @@ should be created in. It can only be an organization number (such as
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -947,7 +947,7 @@ should be created in. It can only be an organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1030,7 +1030,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>name</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the feed and it must be in the format of:
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
@@ -1081,7 +1081,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task">Task</a></code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span></code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1110,7 +1110,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -1125,7 +1125,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task">Task</a></code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span></code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1172,7 +1172,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task">Task</a></code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span></code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1204,7 +1204,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -1219,7 +1219,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task">Task</a></code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span></code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1243,7 +1243,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>name</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the feed and it must be in the format of:
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
@@ -1266,7 +1266,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task">Task</a></code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span></code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1290,7 +1290,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>name</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the feed and it must be in the format of:
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
@@ -1298,7 +1298,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -1313,7 +1313,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task">Task</a></code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span></code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1419,7 +1419,7 @@ finishes within 5 minutes.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1457,7 +1457,7 @@ finishes within 5 minutes.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -1472,7 +1472,7 @@ finishes within 5 minutes.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1587,7 +1587,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>name</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the Feed and it must be in the format of:
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the Feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
@@ -1657,7 +1657,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1689,7 +1689,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -1704,7 +1704,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1748,7 +1748,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1777,7 +1777,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -1792,7 +1792,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1816,7 +1816,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>name</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the Feed and it must be in the format of:
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the Feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
@@ -1839,7 +1839,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1863,7 +1863,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>name</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The name of the Feed and it must be in the format of:
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The name of the Feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
@@ -1871,7 +1871,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -1886,7 +1886,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1919,13 +1919,13 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
+        <td><code><span class="xref">System.String</span></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
 page.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageSize</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.Int32</span>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
 <code>null</code> or <code>0</code> uses a server-defined page size.</p>
 </td>
       </tr>
@@ -2016,7 +2016,7 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>parent</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. Name of the organization or project the assets belong to. Format:
+        <td><code><span class="xref">System.String</span></code><br><p>Required. Name of the organization or project the assets belong to. Format:
 &quot;organizations/[organization-number]&quot; (such as &quot;organizations/123&quot;),
 &quot;projects/[project-id]&quot; (such as &quot;projects/my-project-id&quot;), or
 &quot;projects/[project-number]&quot; (such as &quot;projects/12345&quot;).</p>
@@ -2024,13 +2024,13 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
+        <td><code><span class="xref">System.String</span></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
 page.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageSize</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.Int32</span>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
 <code>null</code> or <code>0</code> uses a server-defined page size.</p>
 </td>
       </tr>
@@ -2084,13 +2084,13 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
+        <td><code><span class="xref">System.String</span></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
 page.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageSize</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.Int32</span>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
 <code>null</code> or <code>0</code> uses a server-defined page size.</p>
 </td>
       </tr>
@@ -2181,7 +2181,7 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>parent</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. Name of the organization or project the assets belong to. Format:
+        <td><code><span class="xref">System.String</span></code><br><p>Required. Name of the organization or project the assets belong to. Format:
 &quot;organizations/[organization-number]&quot; (such as &quot;organizations/123&quot;),
 &quot;projects/[project-id]&quot; (such as &quot;projects/my-project-id&quot;), or
 &quot;projects/[project-number]&quot; (such as &quot;projects/12345&quot;).</p>
@@ -2189,13 +2189,13 @@ response.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
+        <td><code><span class="xref">System.String</span></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
 page.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageSize</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.Int32</span>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
 <code>null</code> or <code>0</code> uses a server-defined page size.</p>
 </td>
       </tr>
@@ -2284,7 +2284,7 @@ page.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>parent</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The parent project/folder/organization whose feeds are to be
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The parent project/folder/organization whose feeds are to be
 listed. It can only be using project/folder/organization number (such as
 &quot;folders/12345&quot;)&quot;, or a project ID (such as &quot;projects/my-project-id&quot;).</p>
 </td>
@@ -2350,7 +2350,7 @@ listed. It can only be using project/folder/organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -2379,7 +2379,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -2394,7 +2394,7 @@ listed. It can only be using project/folder/organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -2418,7 +2418,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
       <tr>
         <td><span class="parametername"><code>parent</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The parent project/folder/organization whose feeds are to be
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The parent project/folder/organization whose feeds are to be
 listed. It can only be using project/folder/organization number (such as
 &quot;folders/12345&quot;)&quot;, or a project ID (such as &quot;projects/my-project-id&quot;).</p>
 </td>
@@ -2440,7 +2440,7 @@ listed. It can only be using project/folder/organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -2464,14 +2464,14 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
       <tr>
         <td><span class="parametername"><code>parent</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. The parent project/folder/organization whose feeds are to be
+        <td><code><span class="xref">System.String</span></code><br><p>Required. The parent project/folder/organization whose feeds are to be
 listed. It can only be using project/folder/organization number (such as
 &quot;folders/12345&quot;)&quot;, or a project ID (such as &quot;projects/my-project-id&quot;).</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -2486,7 +2486,7 @@ listed. It can only be using project/folder/organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -2511,7 +2511,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
       <tr>
         <td><span class="parametername"><code>operationName</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The name of a previously invoked operation. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The name of a previously invoked operation. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
@@ -2556,7 +2556,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
       <tr>
         <td><span class="parametername"><code>operationName</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The name of a previously invoked operation. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The name of a previously invoked operation. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
@@ -2576,7 +2576,7 @@ listed. It can only be using project/folder/organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;&gt;</code></td>
         <td><p>A task representing the result of polling the operation.</p>
 </td>
       </tr>
@@ -2600,7 +2600,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
       <tr>
         <td><span class="parametername"><code>operationName</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The name of a previously invoked operation. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The name of a previously invoked operation. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
@@ -2645,7 +2645,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
       <tr>
         <td><span class="parametername"><code>operationName</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The name of a previously invoked operation. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The name of a previously invoked operation. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
@@ -2665,7 +2665,7 @@ listed. It can only be using project/folder/organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;&gt;</code></td>
         <td><p>A task representing the result of polling the operation.</p>
 </td>
       </tr>
@@ -2739,7 +2739,7 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>scope</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. A scope can be a project, a folder, or an organization. The search is
+        <td><code><span class="xref">System.String</span></code><br><p>Required. A scope can be a project, a folder, or an organization. The search is
 limited to the IAM policies within the <code>scope</code>. The caller must be granted
 the
 <a href="https://cloud.google.com/asset-inventory/docs/access-control#required_permissions"><code>cloudasset.assets.searchAllIamPolicies</code></a>
@@ -2755,7 +2755,7 @@ permission on the desired scope.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>query</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-iam-policies#how_to_construct_a_query">how to construct a
+        <td><code><span class="xref">System.String</span></code><br><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-iam-policies#how_to_construct_a_query">how to construct a
 query</a>
 for more information. If not specified or empty, it will search all the
 IAM policies within the specified <code>scope</code>. Note that the query string is
@@ -2797,13 +2797,13 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
       </tr>
       <tr>
         <td><span class="parametername"><code>pageToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
+        <td><code><span class="xref">System.String</span></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
 page.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageSize</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.Int32</span>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
 <code>null</code> or <code>0</code> uses a server-defined page size.</p>
 </td>
       </tr>
@@ -2898,7 +2898,7 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>scope</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. A scope can be a project, a folder, or an organization. The search is
+        <td><code><span class="xref">System.String</span></code><br><p>Required. A scope can be a project, a folder, or an organization. The search is
 limited to the IAM policies within the <code>scope</code>. The caller must be granted
 the
 <a href="https://cloud.google.com/asset-inventory/docs/access-control#required_permissions"><code>cloudasset.assets.searchAllIamPolicies</code></a>
@@ -2914,7 +2914,7 @@ permission on the desired scope.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>query</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-iam-policies#how_to_construct_a_query">how to construct a
+        <td><code><span class="xref">System.String</span></code><br><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-iam-policies#how_to_construct_a_query">how to construct a
 query</a>
 for more information. If not specified or empty, it will search all the
 IAM policies within the specified <code>scope</code>. Note that the query string is
@@ -2956,13 +2956,13 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
       </tr>
       <tr>
         <td><span class="parametername"><code>pageToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
+        <td><code><span class="xref">System.String</span></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
 page.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageSize</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.Int32</span>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
 <code>null</code> or <code>0</code> uses a server-defined page size.</p>
 </td>
       </tr>
@@ -3057,7 +3057,7 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>scope</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. A scope can be a project, a folder, or an organization. The search is
+        <td><code><span class="xref">System.String</span></code><br><p>Required. A scope can be a project, a folder, or an organization. The search is
 limited to the resources within the <code>scope</code>. The caller must be granted the
 <a href="https://cloud.google.com/asset-inventory/docs/access-control#required_permissions"><code>cloudasset.assets.searchAllResources</code></a>
 permission on the desired scope.</p>
@@ -3072,7 +3072,7 @@ permission on the desired scope.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>query</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-resources#how_to_construct_a_query">how to construct a
+        <td><code><span class="xref">System.String</span></code><br><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-resources#how_to_construct_a_query">how to construct a
 query</a>
 for more information. If not specified or empty, it will search all the
 resources within the specified <code>scope</code>.</p>
@@ -3116,7 +3116,7 @@ location.</li>
       </tr>
       <tr>
         <td><span class="parametername"><code>assetTypes</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code><br><p>Optional. A list of asset types that this request searches for. If empty, it will
+        <td><code><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<span class="xref">System.String</span>&gt;</code><br><p>Optional. A list of asset types that this request searches for. If empty, it will
 search all the <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types#searchable_asset_types">searchable asset
 types</a>.</p>
 <p>Regular expressions are also supported. For example:</p>
@@ -3133,13 +3133,13 @@ supported asset type, an INVALID_ARGUMENT error will be returned.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
+        <td><code><span class="xref">System.String</span></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
 page.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageSize</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.Int32</span>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
 <code>null</code> or <code>0</code> uses a server-defined page size.</p>
 </td>
       </tr>
@@ -3234,7 +3234,7 @@ otherwise the request will be rejected.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>scope</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Required. A scope can be a project, a folder, or an organization. The search is
+        <td><code><span class="xref">System.String</span></code><br><p>Required. A scope can be a project, a folder, or an organization. The search is
 limited to the resources within the <code>scope</code>. The caller must be granted the
 <a href="https://cloud.google.com/asset-inventory/docs/access-control#required_permissions"><code>cloudasset.assets.searchAllResources</code></a>
 permission on the desired scope.</p>
@@ -3249,7 +3249,7 @@ permission on the desired scope.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>query</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-resources#how_to_construct_a_query">how to construct a
+        <td><code><span class="xref">System.String</span></code><br><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-resources#how_to_construct_a_query">how to construct a
 query</a>
 for more information. If not specified or empty, it will search all the
 resources within the specified <code>scope</code>.</p>
@@ -3293,7 +3293,7 @@ location.</li>
       </tr>
       <tr>
         <td><span class="parametername"><code>assetTypes</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code><br><p>Optional. A list of asset types that this request searches for. If empty, it will
+        <td><code><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<span class="xref">System.String</span>&gt;</code><br><p>Optional. A list of asset types that this request searches for. If empty, it will
 search all the <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types#searchable_asset_types">searchable asset
 types</a>.</p>
 <p>Regular expressions are also supported. For example:</p>
@@ -3310,13 +3310,13 @@ supported asset type, an INVALID_ARGUMENT error will be returned.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
+        <td><code><span class="xref">System.String</span></code><br><p>The token returned from the previous request. A value of <code>null</code> or an empty string retrieves the first
 page.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>pageSize</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.nullable-1">Nullable</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
+        <td><code><span class="xref">System.Nullable</span>&lt;<span class="xref">System.Int32</span>&gt;</code><br><p>The size of page to request. The response will not be larger than this, but may be smaller. A value of
 <code>null</code> or <code>0</code> uses a server-defined page size.</p>
 </td>
       </tr>
@@ -3362,7 +3362,7 @@ affected.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task">Task</a></code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span></code></td>
         <td><p>A task representing the asynchronous shutdown operation.</p>
 </td>
       </tr>
@@ -3507,7 +3507,7 @@ organizations/organization_number/feeds/feed_id.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -3540,7 +3540,7 @@ organizations/organization_number/feeds/feed_id.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -3555,7 +3555,7 @@ organizations/organization_number/feeds/feed_id.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -3599,7 +3599,7 @@ organizations/organization_number/feeds/feed_id.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -3628,7 +3628,7 @@ organizations/organization_number/feeds/feed_id.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br><p>A <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a> to use for this RPC.</p>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br><p>A <span class="xref">System.Threading.CancellationToken</span> to use for this RPC.</p>
 </td>
       </tr>
     </tbody>
@@ -3643,7 +3643,7 @@ organizations/organization_number/feeds/feed_id.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
@@ -18,7 +18,7 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a>&gt;</span> <span> &gt; </span>
     <span class="xref">AssetServiceClientBuilder</span>
   </div>
@@ -97,16 +97,16 @@
       <span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.CanUseChannelPool</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -205,7 +205,7 @@
       </tr>
       <tr>
         <td><span class="parametername"><code>cancellationToken</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken">CancellationToken</a></code><br></td>
+        <td><code><span class="xref">System.Threading.CancellationToken</span></code><br></td>
       </tr>
     </tbody>
   </table>
@@ -219,7 +219,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -267,7 +267,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -291,7 +291,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1">IReadOnlyList</a>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">System.Collections.Generic.IReadOnlyList</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
@@ -18,7 +18,7 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a></span> <span> &gt; </span>
     <span class="xref">AssetServiceClientImpl</span>
   </div>
@@ -166,16 +166,16 @@
       <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_PollOnceAnalyzeIamPolicyLongrunningAsync_System_String_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.PollOnceAnalyzeIamPolicyLongrunningAsync(String, CallSettings)</a>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -377,7 +377,7 @@ which resources.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -485,7 +485,7 @@ request to help callers to map responses to requests.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a>&gt;&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -589,7 +589,7 @@ error.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -683,7 +683,7 @@ asset updates.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -759,7 +759,7 @@ asset updates.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task">Task</a></code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span></code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -869,7 +869,7 @@ finishes within 5 minutes.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<span class="xref">Google.LongRunning.Operation</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>, <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -961,7 +961,7 @@ finishes within 5 minutes.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1147,7 +1147,7 @@ response.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>
@@ -1435,7 +1435,7 @@ otherwise the request will be rejected.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.threading.tasks.task-1">Task</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
+        <td><code><span class="xref">System.Threading.Tasks.Task</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</code></td>
         <td><p>A Task containing the RPC response.</p>
 </td>
       </tr>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
@@ -18,7 +18,7 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span><span class="xref">Google.Api.Gax.Grpc.ServiceSettingsBase</span></span> <span> &gt; </span>
     <span class="xref">AssetServiceSettings</span>
   </div>
@@ -40,16 +40,16 @@
       <span class="xref">Google.Api.Gax.Grpc.ServiceSettingsBase.Interceptor</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">BatchGetAssetsHistoryRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -99,7 +99,7 @@ size of the asset name list is 100 in one request.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -145,7 +145,7 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">BatchGetAssetsHistoryResponse</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">BigQueryDestination</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -97,7 +97,7 @@ an INVALID_ARGUMENT error.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -122,7 +122,7 @@ call returns an INVALID_ARGUMEMT error.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -203,7 +203,7 @@ persist and there will not be partial results persisting in a table.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -227,7 +227,7 @@ will be created.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ConditionEvaluation.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ConditionEvaluation.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ConditionEvaluation.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ConditionEvaluation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ConditionEvaluation.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ConditionEvaluation</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ConditionEvaluation.html">ConditionEvaluation</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ConditionEvaluation.html">ConditionEvaluation</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ConditionEvaluation.html">ConditionEvaluation</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ConditionEvaluation.html">ConditionEvaluation</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">CreateFeedRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -121,7 +121,7 @@ be unique under a specific parent project/folder/organization.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -147,7 +147,7 @@ should be created in. It can only be an organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -16,13 +16,13 @@
   </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">DeleteFeedRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -30,16 +30,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -117,7 +117,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ExportAssetsRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -109,7 +109,7 @@ for all supported asset types.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -179,7 +179,7 @@ or a folder number (such as &quot;folders/123&quot;).</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -20,13 +20,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ExportAssetsResponse</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -34,16 +34,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -22,13 +22,13 @@ Pub/Sub topics.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">Feed</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -36,16 +36,16 @@ Pub/Sub topics.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -105,7 +105,7 @@ for more info.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -133,7 +133,7 @@ for a list of all supported asset types.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -259,7 +259,7 @@ project/folder/organization.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -18,21 +18,21 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">FeedName</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Api.Gax.IResourceName</span>,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>&gt;</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -60,12 +60,12 @@
       </tr>
       <tr>
         <td><span class="parametername"><code>projectId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Project</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Project</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
     </tbody>
@@ -89,7 +89,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -111,7 +111,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -133,7 +133,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -156,7 +156,7 @@ instance.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -178,7 +178,7 @@ instance.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -249,12 +249,12 @@ unparsed resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>projectId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Project</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Project</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
     </tbody>
@@ -269,7 +269,7 @@ unparsed resource name.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td><p>The string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern <code>projects/{project}/feeds/{feed}</code>
 .</p>
 </td>
@@ -295,12 +295,12 @@ unparsed resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>folderId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Folder</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Folder</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
     </tbody>
@@ -315,7 +315,7 @@ unparsed resource name.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td><p>The string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern <code>folders/{folder}/feeds/{feed}</code>.</p>
 </td>
       </tr>
@@ -340,12 +340,12 @@ unparsed resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>organizationId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Organization</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Organization</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
     </tbody>
@@ -360,7 +360,7 @@ unparsed resource name.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td><p>The string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>organizations/{organization}/feeds/{feed}</code>.</p>
 </td>
@@ -386,12 +386,12 @@ unparsed resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>projectId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Project</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Project</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
     </tbody>
@@ -406,7 +406,7 @@ unparsed resource name.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td><p>The string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern <code>projects/{project}/feeds/{feed}</code>
 .</p>
 </td>
@@ -431,12 +431,12 @@ unparsed resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>folderId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Folder</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Folder</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
     </tbody>
@@ -475,12 +475,12 @@ unparsed resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>organizationId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Organization</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Organization</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
     </tbody>
@@ -519,12 +519,12 @@ unparsed resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>projectId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Project</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Project</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedId</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The <code>Feed</code> ID. Must not be <code>null</code> or empty.</p>
 </td>
       </tr>
     </tbody>
@@ -601,13 +601,13 @@ unparsed resource name.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a></code></td>
+        <td><code><span class="xref">System.Int32</span></code></td>
         <td></td>
       </tr>
     </tbody>
   </table>
   <strong>Overrides</strong>
-  <div><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a></div>
+  <div><span class="xref">System.Object.GetHashCode()</span></div>
   <a id="Google_Cloud_Asset_V1_FeedName_Parse_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String)" class="notranslate">Parse(String)</h3>
   <div class="codewrapper">
@@ -626,7 +626,7 @@ unparsed resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedName</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The resource name in string form. Must not be <code>null</code>.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The resource name in string form. Must not be <code>null</code>.</p>
 </td>
       </tr>
     </tbody>
@@ -670,13 +670,13 @@ unparseable resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedName</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The resource name in string form. Must not be <code>null</code>.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The resource name in string form. Must not be <code>null</code>.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>allowUnparsed</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code><br><p>If <code>true</code> will successfully store an unparseable resource name into the <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html#Google_Cloud_Asset_V1_FeedName_UnparsedResource">UnparsedResource</a>
-property; otherwise will throw an <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.argumentexception">ArgumentException</a> if an unparseable resource name is
+        <td><code><span class="xref">System.Boolean</span></code><br><p>If <code>true</code> will successfully store an unparseable resource name into the <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html#Google_Cloud_Asset_V1_FeedName_UnparsedResource">UnparsedResource</a>
+property; otherwise will throw an <span class="xref">System.ArgumentException</span> if an unparseable resource name is
 specified.</p>
 </td>
       </tr>
@@ -720,14 +720,14 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td><p>The string representation of the resource name.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <strong>Overrides</strong>
-  <div><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a></div>
+  <div><span class="xref">System.Object.ToString()</span></div>
   <a id="Google_Cloud_Asset_V1_FeedName_TryParse_" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,Google.Cloud.Asset.V1.FeedName@)" class="notranslate">TryParse(String, out FeedName)</h3>
   <div class="codewrapper">
@@ -746,7 +746,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
       </tr>
       <tr>
         <td><span class="parametername"><code>feedName</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The resource name in string form. Must not be <code>null</code>.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The resource name in string form. Must not be <code>null</code>.</p>
 </td>
       </tr>
       <tr>
@@ -766,7 +766,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td><p><code>true</code> if the name was parsed successfully; <code>false</code> otherwise.</p>
 </td>
       </tr>
@@ -795,13 +795,13 @@ allowing an unparseable resource name.</p>
       </tr>
       <tr>
         <td><span class="parametername"><code>feedName</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code><br><p>The resource name in string form. Must not be <code>null</code>.</p>
+        <td><code><span class="xref">System.String</span></code><br><p>The resource name in string form. Must not be <code>null</code>.</p>
 </td>
       </tr>
       <tr>
         <td><span class="parametername"><code>allowUnparsed</code></span></td>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code><br><p>If <code>true</code> will successfully store an unparseable resource name into the <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html#Google_Cloud_Asset_V1_FeedName_UnparsedResource">UnparsedResource</a>
-property; otherwise will throw an <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.argumentexception">ArgumentException</a> if an unparseable resource name is
+        <td><code><span class="xref">System.Boolean</span></code><br><p>If <code>true</code> will successfully store an unparseable resource name into the <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html#Google_Cloud_Asset_V1_FeedName_UnparsedResource">UnparsedResource</a>
+property; otherwise will throw an <span class="xref">System.ArgumentException</span> if an unparseable resource name is
 specified.</p>
 </td>
       </tr>
@@ -822,7 +822,7 @@ specified.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td><p><code>true</code> if the name was parsed successfully; <code>false</code> otherwise.</p>
 </td>
       </tr>
@@ -869,7 +869,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -908,7 +908,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">FeedOutputConfig</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">GcsDestination</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -121,7 +121,7 @@ overwritten with the exported result.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -151,7 +151,7 @@ already exists.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">GcsOutputResult</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -95,7 +95,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">GetFeedRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -119,7 +119,7 @@ organizations/organization_number/feeds/feed_id</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -96,7 +96,7 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -148,7 +148,7 @@ on the [partition_key].</li>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -182,7 +182,7 @@ if BigQuery is able to complete the job successfully. Details are at
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisOutputConfig.Types.GcsDestination</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -101,7 +101,7 @@ overwritten with the analysis result.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisOutputConfig.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisOutputConfig</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -22,13 +22,13 @@ less than 10.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisQuery.Types.AccessSelector</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -36,16 +36,16 @@ less than 10.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -98,7 +98,7 @@ less than 10.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -120,7 +120,7 @@ less than 10.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisQuery.Types.ConditionContext</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html">IamPolicyAnalysisQuery.Types.ConditionContext</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html">IamPolicyAnalysisQuery.Types.ConditionContext</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html">IamPolicyAnalysisQuery.Types.ConditionContext</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html">IamPolicyAnalysisQuery.Types.ConditionContext</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -20,13 +20,13 @@ directly or indirectly.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisQuery.Types.IdentitySelector</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -34,16 +34,16 @@ directly or indirectly.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -105,7 +105,7 @@ You must give a specific identity.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisQuery.Types.Options</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -113,7 +113,7 @@ F. And those advanced analysis results will be included in
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -140,7 +140,7 @@ is not allowed to set.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -178,7 +178,7 @@ users who have permission P on that project or any lower resource.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -205,7 +205,7 @@ is not allowed to set.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -229,7 +229,7 @@ Default is false.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -253,7 +253,7 @@ Default is false.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -20,13 +20,13 @@ projects.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisQuery.Types.ResourceSelector</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -34,16 +34,16 @@ projects.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -98,7 +98,7 @@ types</a>.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisQuery.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisQuery</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -212,7 +212,7 @@ folder number (such as &quot;folders/123&quot;), a project ID (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisResult.Types.Access</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -136,7 +136,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -158,7 +158,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -33,13 +33,13 @@ combinations.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisResult.Types.AccessControlList</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -47,16 +47,16 @@ combinations.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisResult.Types.Edge</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -95,7 +95,7 @@ name for a resource node or an email of an identity.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -118,7 +118,7 @@ name for a resource node or an email of an identity.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisResult.Types.Identity</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -128,7 +128,7 @@ as:</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisResult.Types.IdentityList</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisResult.Types.Resource</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -117,7 +117,7 @@ name</a></p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisResult.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -19,13 +19,13 @@ access control lists.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisResult</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -33,16 +33,16 @@ access control lists.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -120,7 +120,7 @@ of the resource to which the [iam_binding][google.cloud.asset.v1.IamPolicyAnalys
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -143,7 +143,7 @@ finished.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -19,13 +19,13 @@ resource, an identity or an access.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicyAnalysisState</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -33,16 +33,16 @@ resource, an identity or an access.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -95,7 +95,7 @@ resource, an identity or an access.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicySearchResult.Types.Explanation.Types.Permissions</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -94,7 +94,7 @@
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicySearchResult.Types.Explanation.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicySearchResult.Types.Explanation</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -100,7 +100,7 @@ map is populated only for requests with permission queries.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.MapField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>, <a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.MapField</span>&lt;<span class="xref">System.String</span>, <a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicySearchResult.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">IamPolicySearchResult</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -160,7 +160,7 @@ orgnization, this field will be empty.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -191,7 +191,7 @@ for more information.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ListAssetsRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
@@ -33,16 +33,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -110,7 +110,7 @@ for all supported asset types.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -156,7 +156,7 @@ is 100, minimum is 1, and maximum is 1000.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a></code></td>
+        <td><code><span class="xref">System.Int32</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -180,7 +180,7 @@ prior <code>ListAssets</code> call, and the API should return the next page of a
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -205,7 +205,7 @@ prior <code>ListAssets</code> call, and the API should return the next page of a
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsResponse.html
@@ -18,33 +18,33 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ListAssetsResponse</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsResponse.html">ListAssetsResponse</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsResponse.html">ListAssetsResponse</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsResponse.html">ListAssetsResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListAssetsResponse.html">ListAssetsResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
     <span><span class="xref">Google.Api.Gax.Grpc.IPageResponse</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.ienumerable">IEnumerable</a></span>
+    <span><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
+    <span><span class="xref">System.Collections.IEnumerable</span></span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -121,7 +121,7 @@ remaining results.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -167,7 +167,7 @@ remaining results.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1">IEnumerator</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;</code></td>
+        <td><code><span class="xref">System.Collections.Generic.IEnumerator</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -189,7 +189,7 @@ remaining results.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.ienumerator">IEnumerator</a></code></td>
+        <td><code><span class="xref">System.Collections.IEnumerator</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ListFeedsRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -96,7 +96,7 @@ listed. It can only be using project/folder/organization number (such as
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -16,13 +16,13 @@
   </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ListFeedsResponse</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -30,16 +30,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">OutputConfig</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">OutputResult</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PartitionSpec.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PartitionSpec.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">PartitionSpec.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PartitionSpec.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PartitionSpec.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">PartitionSpec</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PartitionSpec.html">PartitionSpec</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PartitionSpec.html">PartitionSpec</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PartitionSpec.html">PartitionSpec</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PartitionSpec.html">PartitionSpec</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">PubsubDestination</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -95,7 +95,7 @@ Example: <code>projects/PROJECT_ID/topics/TOPIC_ID</code>.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">Resource</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -121,7 +121,7 @@ discovery document, such as Cloud Bigtable.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -146,7 +146,7 @@ discovery document, such as Cloud Bigtable.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -169,7 +169,7 @@ For more information, see <a href="https://cloud.google.com/about/locations/">ht
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -200,7 +200,7 @@ Example:
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -225,7 +225,7 @@ URL returns the resource itself. Example:
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -247,7 +247,7 @@ URL returns the resource itself. Example:
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">ResourceSearchResult</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -137,7 +137,7 @@ version.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -198,7 +198,7 @@ proto contains it.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -226,7 +226,7 @@ resource&apos;s proto contains it.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -256,7 +256,7 @@ belongs to one or more folders.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -287,7 +287,7 @@ name. This field is available only when the resource&apos;s proto contains it.</
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -320,7 +320,7 @@ proto contains it.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.MapField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>, <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.MapField</span>&lt;<span class="xref">System.String</span>, <span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -349,7 +349,7 @@ contains it.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -380,7 +380,7 @@ for more information.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -411,7 +411,7 @@ proto contains it.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -441,7 +441,7 @@ resource belongs to an organization.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -470,7 +470,7 @@ resource belongs to an organization.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -499,7 +499,7 @@ To search against the <code>parent_full_resource_name</code>:</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -529,7 +529,7 @@ belongs to a project.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -568,7 +568,7 @@ Reference</a>.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">SearchAllIamPoliciesRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
@@ -33,16 +33,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -98,7 +98,7 @@ there could be more results as long as <code>next_page_token</code> is returned.
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a></code></td>
+        <td><code><span class="xref">System.Int32</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -123,7 +123,7 @@ identical to those in the previous call.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -182,7 +182,7 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -215,7 +215,7 @@ permission on the desired scope.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -18,33 +18,33 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">SearchAllIamPoliciesResponse</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
     <span><span class="xref">Google.Api.Gax.Grpc.IPageResponse</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.ienumerable">IEnumerable</a></span>
+    <span><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
+    <span><span class="xref">System.Collections.IEnumerable</span></span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -99,7 +99,7 @@ the next set of results, call this method again, using this value as the
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -146,7 +146,7 @@ as the associated resource is returned along with the policy.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1">IEnumerator</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</code></td>
+        <td><code><span class="xref">System.Collections.Generic.IEnumerator</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -168,7 +168,7 @@ as the associated resource is returned along with the policy.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.ienumerator">IEnumerator</a></code></td>
+        <td><code><span class="xref">System.Collections.IEnumerator</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">SearchAllResourcesRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
@@ -33,16 +33,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -107,7 +107,7 @@ supported asset type, an INVALID_ARGUMENT error will be returned.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a>&gt;</code></td>
+        <td><code><span class="xref">Google.Protobuf.Collections.RepeatedField</span>&lt;<span class="xref">System.String</span>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -150,7 +150,7 @@ are not supported.</li>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -175,7 +175,7 @@ there could be more results as long as <code>next_page_token</code> is returned.
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.int32">Int32</a></code></td>
+        <td><code><span class="xref">System.Int32</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -200,7 +200,7 @@ identical to those in the previous call.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -261,7 +261,7 @@ location.</li>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -293,7 +293,7 @@ permission on the desired scope.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -18,33 +18,33 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">SearchAllResourcesResponse</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
     <span><span class="xref">Google.Api.Gax.Grpc.IPageResponse</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.ienumerable">IEnumerable</a></span>
+    <span><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
+    <span><span class="xref">System.Collections.IEnumerable</span></span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -99,7 +99,7 @@ method again using the value of <code>next_page_token</code> as <code>page_token
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.string">String</a></code></td>
+        <td><code><span class="xref">System.String</span></code></td>
         <td></td>
       </tr>
     </tbody>
@@ -146,7 +146,7 @@ standard metadata information.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1">IEnumerator</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</code></td>
+        <td><code><span class="xref">System.Collections.Generic.IEnumerator</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</code></td>
         <td></td>
       </tr>
     </tbody>
@@ -168,7 +168,7 @@ standard metadata information.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.collections.ienumerator">IEnumerator</a></code></td>
+        <td><code><span class="xref">System.Collections.IEnumerator</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.html
@@ -18,22 +18,22 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">TemporalAsset.Types</span>
   </div>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -19,13 +19,13 @@ when it was observed and its status during that window.</p>
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">TemporalAsset</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -33,16 +33,16 @@ when it was observed and its status during that window.</p>
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>
@@ -117,7 +117,7 @@ when it was observed and its status during that window.</p>
         <td><strong>Description</strong></td>
       </tr>
       <tr>
-        <td><code><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.boolean">Boolean</a></code></td>
+        <td><code><span class="xref">System.Boolean</span></code></td>
         <td></td>
       </tr>
     </tbody>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">TimeWindow</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -18,13 +18,13 @@
 </div>
   <div class="inheritance">
     <h2>Inheritance</h2>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object">Object</a></span> <span> &gt; </span>
+    <span><span class="xref">System.Object</span></span> <span> &gt; </span>
     <span class="xref">UpdateFeedRequest</span>
   </div>
   <div classs="implements">
     <h2>Implements</h2>
     <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;,</span>
-    <span><a class="xref" href="https://learn.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;,</span>
     <span><span class="xref">Google.Protobuf.IBufferMessage</span>,</span>
     <span><span class="xref">Google.Protobuf.IMessage</span></span>
@@ -32,16 +32,16 @@
   <div class="inheritedMembers expandable">
     <h2 class="showalways">Inherited Members</h2>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gethashcode#system-object-gethashcode">Object.GetHashCode()</a>
+      <span class="xref">System.Object.GetHashCode()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.gettype#system-object-gettype">Object.GetType()</a>
+      <span class="xref">System.Object.GetType()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.memberwiseclone#system-object-memberwiseclone">Object.MemberwiseClone()</a>
+      <span class="xref">System.Object.MemberwiseClone()</span>
     </div>
     <div>
-      <a class="xref" href="https://learn.microsoft.com/dotnet/api/system.object.tostring#system-object-tostring">Object.ToString()</a>
+      <span class="xref">System.Object.ToString()</span>
     </div>
   </div>
   <h2>Namespace</h2>


### PR DESCRIPTION
We didn't change anything in our setup, so I'm not sure why these standard library xrefs are no longer being linked. However, this fixes our golden tests, which are currently broken.