### PR TITLE
fix: remove === in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ dependencies = [
     "gcp-docuploader",
     "semver",
     "six",
-    "protobuf===3.20.3",  # DO NOT UPGRADE. Keep pinned to 3.20.3.
+    "protobuf==3.20.3",  # DO NOT UPGRADE. Keep pinned to 3.20.3.
 ]
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
The `===` in `setup.py` is causing issues when installing locally. See the stack trace below:

```

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/pip/_internal/commands/install.py", line 572, in _determine_conflicts
    return check_install_conflicts(to_install)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pip/_internal/operations/check.py", line 103, in check_install_conflicts
    would_be_installed = _simulate_installation_of(to_install, package_set)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pip/_internal/operations/check.py", line 128, in _simulate_installation_of
    package_set[name] = PackageDetails(dist.version, list(dist.iter_dependencies()))
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_dists.py", line 218, in iter_dependencies
    req = Requirement(req_string)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pip/_vendor/packaging/requirements.py", line 104, in __init__
    raise InvalidRequirement(
pip._vendor.packaging.requirements.InvalidRequirement: Parse error at "'(===3.20'": Expected string_end
```