### PR TITLE
fix: remove wrap-code class for Python to fix whitespace issues

### DIFF
--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.client.BigQueryReadClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.client.BigQueryReadClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Client for interacting with BigQuery Storage API.</p>
 <p>The BigQuery storage API can be used to read data stored in BigQuery.</p>
@@ -49,7 +49,7 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient" class="notranslate">BigQueryReadClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query read client.</p>
 </div>
@@ -121,7 +121,7 @@
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient___exit__" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.__exit__" class="notranslate">__exit__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__exit__(type, value, traceback)</code></pre>
+    <pre class="prettyprint"><code>__exit__(type, value, traceback)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Releases underlying transport&#39;s resources.</p>
 <p>.. warning::
@@ -131,37 +131,37 @@
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_create_read_session" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.create_read_session" class="notranslate">create_read_session</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_read_session(
+    <pre class="prettyprint"><code>create_read_session(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.CreateReadSessionRequest,
@@ -300,7 +300,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -343,7 +343,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -386,7 +386,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -429,7 +429,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -503,55 +503,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_parse_read_session_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.parse_read_session_path" class="notranslate">parse_read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_session_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_session_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_session path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_parse_read_stream_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.parse_read_stream_path" class="notranslate">parse_read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_read_rows" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.read_rows" class="notranslate">read_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_rows(
+    <pre class="prettyprint"><code>read_rows(
     name,
     offset=0,
     retry=_MethodDefault._DEFAULT_VALUE,
@@ -707,19 +707,19 @@ read_rows_stream = client.read_rows(stream.name)</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_read_session_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.read_session_path" class="notranslate">read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_session_path(project: str, location: str, session: str)</code></pre>
+    <pre class="prettyprint"><code>read_session_path(project: str, location: str, session: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_session string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_read_stream_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.read_stream_path" class="notranslate">read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_stream string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_split_read_stream" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.split_read_stream" class="notranslate">split_read_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>split_read_stream(
+    <pre class="prettyprint"><code>split_read_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.SplitReadStreamRequest, dict
@@ -814,7 +814,7 @@ once the streams have been read to completion.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_table_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Write API.
 The Write API can be used to write data to BigQuery.
@@ -51,7 +51,7 @@ For supplementary information about the Write API, see:
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient" class="notranslate">BigQueryWriteClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query write client.</p>
 </div>
@@ -123,7 +123,7 @@ For supplementary information about the Write API, see:
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient___exit__" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.__exit__" class="notranslate">__exit__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__exit__(type, value, traceback)</code></pre>
+    <pre class="prettyprint"><code>__exit__(type, value, traceback)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Releases underlying transport&#39;s resources.</p>
 <p>.. warning::
@@ -133,7 +133,7 @@ For supplementary information about the Write API, see:
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_append_rows" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.append_rows" class="notranslate">append_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>append_rows(
+    <pre class="prettyprint"><code>append_rows(
     requests: typing.Optional[
         typing.Iterator[
             google.cloud.bigquery_storage_v1.types.storage.AppendRowsRequest
@@ -248,7 +248,7 @@ rpc), and the stream is explicitly committed via the
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_batch_commit_write_streams" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.batch_commit_write_streams" class="notranslate">batch_commit_write_streams</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>batch_commit_write_streams(
+    <pre class="prettyprint"><code>batch_commit_write_streams(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.BatchCommitWriteStreamsRequest,
@@ -348,37 +348,37 @@ becomes available for read operations.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_create_write_stream" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.create_write_stream" class="notranslate">create_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_write_stream(
+    <pre class="prettyprint"><code>create_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.CreateWriteStreamRequest,
@@ -493,7 +493,7 @@ received.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_finalize_write_stream" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.finalize_write_stream" class="notranslate">finalize_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>finalize_write_stream(
+    <pre class="prettyprint"><code>finalize_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.FinalizeWriteStreamRequest,
@@ -590,7 +590,7 @@ the stream. Finalize is not supported on the &#39;_default&#39; stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_flush_rows" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.flush_rows" class="notranslate">flush_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>flush_rows(
+    <pre class="prettyprint"><code>flush_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.FlushRowsRequest, dict
@@ -692,7 +692,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -735,7 +735,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -778,7 +778,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -821,7 +821,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -895,7 +895,7 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_get_write_stream" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.get_write_stream" class="notranslate">get_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_write_stream(
+    <pre class="prettyprint"><code>get_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.GetWriteStreamRequest, dict
@@ -990,55 +990,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_parse_write_stream_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.parse_write_stream_path" class="notranslate">parse_write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_write_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_write_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a write_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_table_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryWriteClient_write_stream_path" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.write_stream_path" class="notranslate">write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified write_stream string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.client.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.client.html
@@ -18,14 +18,14 @@
   </h2>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.html">BigQueryReadClient</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Client for interacting with BigQuery Storage API.</p>
 <p>The BigQuery storage API can be used to read data stored in BigQuery.</p>
 </div>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1.client.BigQueryWriteClient.html">BigQueryWriteClient</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>BigQuery Write API.
 The Write API can be used to write data to BigQuery.

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsIterable(reader, read_session=None)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsIterable(reader, read_session=None)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>An iterable of rows from a read session.</p>
 </div>
@@ -75,13 +75,13 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsIterable___iter__" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.__iter__" class="notranslate">__iter__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__iter__()</code></pre>
+    <pre class="prettyprint"><code>__iter__()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Iterator for each row in all pages.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsIterable_to_arrow" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.to_arrow" class="notranslate">to_arrow</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>to_arrow()</code></pre>
+    <pre class="prettyprint"><code>to_arrow()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Create a <code>pyarrow.Table</code> of all rows in the stream.</p>
 <p>This method requires the pyarrow library and a stream using the Arrow
@@ -104,7 +104,7 @@ format.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsIterable_to_dataframe" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.to_dataframe" class="notranslate">to_dataframe</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>to_dataframe(dtypes=None)</code></pre>
+    <pre class="prettyprint"><code>to_dataframe(dtypes=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Create a <code>pandas.DataFrame</code> of all rows in the stream.</p>
 <p>This method requires the pandas libary to create a data frame and the

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.reader.ReadRowsPage.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.reader.ReadRowsPage.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsPage(stream_parser, message)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsPage(stream_parser, message)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>An iterator of rows from a read session message.</p>
 </div>
@@ -63,25 +63,25 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsPage___iter__" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsPage.__iter__" class="notranslate">__iter__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__iter__()</code></pre>
+    <pre class="prettyprint"><code>__iter__()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>A <code>ReadRowsPage</code> is an iterator.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsPage___next__" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsPage.__next__" class="notranslate">__next__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__next__()</code></pre>
+    <pre class="prettyprint"><code>__next__()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Get the next row in the page.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsPage_next" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsPage.next" class="notranslate">next</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>next()</code></pre>
+    <pre class="prettyprint"><code>next()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Get the next row in the page.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsPage_to_arrow" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsPage.to_arrow" class="notranslate">to_arrow</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>to_arrow()</code></pre>
+    <pre class="prettyprint"><code>to_arrow()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Create an <code>pyarrow.RecordBatch</code> of rows in the page.</p>
 </div>
@@ -102,7 +102,7 @@
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsPage_to_dataframe" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsPage.to_dataframe" class="notranslate">to_dataframe</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>to_dataframe(dtypes=None)</code></pre>
+    <pre class="prettyprint"><code>to_dataframe(dtypes=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Create a <code>pandas.DataFrame</code> of rows in the page.</p>
 <p>This method requires the pandas libary to create a data frame and the

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.reader.ReadRowsStream.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.reader.ReadRowsStream.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsStream(client, name, offset, read_rows_kwargs, retry_delay_callback=None)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsStream(client, name, offset, read_rows_kwargs, retry_delay_callback=None)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>A stream of results from a read rows request.</p>
 <p>This stream is an iterable of
@@ -37,7 +37,7 @@ other methods in this library.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsStream" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsStream" class="notranslate">ReadRowsStream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsStream(client, name, offset, read_rows_kwargs, retry_delay_callback=None)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsStream(client, name, offset, read_rows_kwargs, retry_delay_callback=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Construct a ReadRowsStream.</p>
 </div>
@@ -119,7 +119,7 @@ other methods in this library.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsStream___iter__" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsStream.__iter__" class="notranslate">__iter__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__iter__()</code></pre>
+    <pre class="prettyprint"><code>__iter__()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>An iterable of messages.</p>
 </div>
@@ -140,7 +140,7 @@ other methods in this library.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsStream_rows" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsStream.rows" class="notranslate">rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>rows(read_session=None)</code></pre>
+    <pre class="prettyprint"><code>rows(read_session=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Iterate over all rows in the stream.</p>
 <p>This method requires the fastavro library in order to parse row
@@ -188,7 +188,7 @@ library is required.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsStream_to_arrow" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsStream.to_arrow" class="notranslate">to_arrow</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>to_arrow(read_session=None)</code></pre>
+    <pre class="prettyprint"><code>to_arrow(read_session=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Create a <code>pyarrow.Table</code> of all rows in the stream.</p>
 <p>This method requires the pyarrow library and a stream using the Arrow
@@ -232,7 +232,7 @@ format.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsStream_to_dataframe" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsStream.to_dataframe" class="notranslate">to_dataframe</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>to_dataframe(read_session=None, dtypes=None)</code></pre>
+    <pre class="prettyprint"><code>to_dataframe(read_session=None, dtypes=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Create a <code>pandas.DataFrame</code> of all rows in the stream.</p>
 <p>This method requires the pandas libary to create a data frame and the

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.reader.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.reader.html
@@ -17,7 +17,7 @@
   </h2>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.html">ReadRowsIterable</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsIterable(reader, read_session=None)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsIterable(reader, read_session=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>An iterable of rows from a read session.</p>
 </div>
@@ -54,7 +54,7 @@
   </table>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1.reader.ReadRowsPage.html">ReadRowsPage</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsPage(stream_parser, message)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsPage(stream_parser, message)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>An iterator of rows from a read session message.</p>
 </div>
@@ -91,7 +91,7 @@
   </table>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1.reader.ReadRowsStream.html">ReadRowsStream</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsStream(client, name, offset, read_rows_kwargs, retry_delay_callback=None)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsStream(client, name, offset, read_rows_kwargs, retry_delay_callback=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>A stream of results from a read rows request.</p>
 <p>This stream is an iterable of

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Read API.
 The Read API can be used to read data from BigQuery.</p>
@@ -47,7 +47,7 @@ The Read API can be used to read data from BigQuery.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient" class="notranslate">BigQueryReadAsyncClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query read client.</p>
 </div>
@@ -109,37 +109,37 @@ The Read API can be used to read data from BigQuery.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_create_read_session" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.create_read_session" class="notranslate">create_read_session</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_read_session(
+    <pre class="prettyprint"><code>create_read_session(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.CreateReadSessionRequest,
@@ -278,7 +278,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -321,7 +321,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -364,7 +364,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -407,7 +407,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -481,61 +481,61 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_get_transport_class" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.get_transport_class" class="notranslate">get_transport_class</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_transport_class()</code></pre>
+    <pre class="prettyprint"><code>get_transport_class()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns an appropriate transport class.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_parse_read_session_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.parse_read_session_path" class="notranslate">parse_read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_session_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_session_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_session path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_parse_read_stream_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.parse_read_stream_path" class="notranslate">parse_read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_read_rows" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.read_rows" class="notranslate">read_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_rows(
+    <pre class="prettyprint"><code>read_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.ReadRowsRequest, dict
@@ -647,19 +647,19 @@ reflecting the current state of the stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_read_session_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.read_session_path" class="notranslate">read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_session_path(project: str, location: str, session: str)</code></pre>
+    <pre class="prettyprint"><code>read_session_path(project: str, location: str, session: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_session string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_read_stream_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.read_stream_path" class="notranslate">read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_stream string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_split_read_stream" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.split_read_stream" class="notranslate">split_read_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>split_read_stream(
+    <pre class="prettyprint"><code>split_read_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.SplitReadStreamRequest, dict
@@ -754,7 +754,7 @@ once the streams have been read to completion.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_table_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Read API.
 The Read API can be used to read data from BigQuery.</p>
@@ -70,7 +70,7 @@ The Read API can be used to read data from BigQuery.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient" class="notranslate">BigQueryReadClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query read client.</p>
 </div>
@@ -142,7 +142,7 @@ The Read API can be used to read data from BigQuery.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient___exit__" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.__exit__" class="notranslate">__exit__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__exit__(type, value, traceback)</code></pre>
+    <pre class="prettyprint"><code>__exit__(type, value, traceback)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Releases underlying transport&#39;s resources.</p>
 <p>.. warning::
@@ -152,37 +152,37 @@ The Read API can be used to read data from BigQuery.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_create_read_session" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.create_read_session" class="notranslate">create_read_session</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_read_session(
+    <pre class="prettyprint"><code>create_read_session(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.CreateReadSessionRequest,
@@ -321,7 +321,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -364,7 +364,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -407,7 +407,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -450,7 +450,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -524,55 +524,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_parse_read_session_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.parse_read_session_path" class="notranslate">parse_read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_session_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_session_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_session path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_parse_read_stream_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.parse_read_stream_path" class="notranslate">parse_read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_read_rows" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.read_rows" class="notranslate">read_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_rows(
+    <pre class="prettyprint"><code>read_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.ReadRowsRequest, dict
@@ -684,19 +684,19 @@ reflecting the current state of the stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_read_session_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.read_session_path" class="notranslate">read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_session_path(project: str, location: str, session: str)</code></pre>
+    <pre class="prettyprint"><code>read_session_path(project: str, location: str, session: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_session string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_read_stream_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.read_stream_path" class="notranslate">read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_stream string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_split_read_stream" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.split_read_stream" class="notranslate">split_read_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>split_read_stream(
+    <pre class="prettyprint"><code>split_read_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.SplitReadStreamRequest, dict
@@ -791,7 +791,7 @@ once the streams have been read to completion.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_table_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Write API.
 The Write API can be used to write data to BigQuery.
@@ -49,7 +49,7 @@ For supplementary information about the Write API, see:
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient" class="notranslate">BigQueryWriteAsyncClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query write client.</p>
 </div>
@@ -111,7 +111,7 @@ For supplementary information about the Write API, see:
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_append_rows" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.append_rows" class="notranslate">append_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>append_rows(
+    <pre class="prettyprint"><code>append_rows(
     requests: typing.Optional[
         typing.AsyncIterator[
             google.cloud.bigquery_storage_v1.types.storage.AppendRowsRequest
@@ -226,7 +226,7 @@ rpc), and the stream is explicitly committed via the
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_batch_commit_write_streams" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.batch_commit_write_streams" class="notranslate">batch_commit_write_streams</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>batch_commit_write_streams(
+    <pre class="prettyprint"><code>batch_commit_write_streams(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.BatchCommitWriteStreamsRequest,
@@ -326,37 +326,37 @@ becomes available for read operations.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_create_write_stream" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.create_write_stream" class="notranslate">create_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_write_stream(
+    <pre class="prettyprint"><code>create_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.CreateWriteStreamRequest,
@@ -471,7 +471,7 @@ received.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_finalize_write_stream" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.finalize_write_stream" class="notranslate">finalize_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>finalize_write_stream(
+    <pre class="prettyprint"><code>finalize_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.FinalizeWriteStreamRequest,
@@ -568,7 +568,7 @@ the stream. Finalize is not supported on the &#39;_default&#39; stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_flush_rows" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.flush_rows" class="notranslate">flush_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>flush_rows(
+    <pre class="prettyprint"><code>flush_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.FlushRowsRequest, dict
@@ -670,7 +670,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -713,7 +713,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -756,7 +756,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -799,7 +799,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -873,13 +873,13 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_get_transport_class" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.get_transport_class" class="notranslate">get_transport_class</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_transport_class()</code></pre>
+    <pre class="prettyprint"><code>get_transport_class()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns an appropriate transport class.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_get_write_stream" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.get_write_stream" class="notranslate">get_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_write_stream(
+    <pre class="prettyprint"><code>get_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.GetWriteStreamRequest, dict
@@ -974,55 +974,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_parse_write_stream_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.parse_write_stream_path" class="notranslate">parse_write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_write_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_write_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a write_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_table_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteAsyncClient_write_stream_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteAsyncClient.write_stream_path" class="notranslate">write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified write_stream string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Write API.
 The Write API can be used to write data to BigQuery.
@@ -49,7 +49,7 @@ For supplementary information about the Write API, see:
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient" class="notranslate">BigQueryWriteClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query write client.</p>
 </div>
@@ -121,7 +121,7 @@ For supplementary information about the Write API, see:
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient___exit__" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.__exit__" class="notranslate">__exit__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__exit__(type, value, traceback)</code></pre>
+    <pre class="prettyprint"><code>__exit__(type, value, traceback)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Releases underlying transport&#39;s resources.</p>
 <p>.. warning::
@@ -131,7 +131,7 @@ For supplementary information about the Write API, see:
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_append_rows" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.append_rows" class="notranslate">append_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>append_rows(
+    <pre class="prettyprint"><code>append_rows(
     requests: typing.Optional[
         typing.Iterator[
             google.cloud.bigquery_storage_v1.types.storage.AppendRowsRequest
@@ -246,7 +246,7 @@ rpc), and the stream is explicitly committed via the
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_batch_commit_write_streams" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.batch_commit_write_streams" class="notranslate">batch_commit_write_streams</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>batch_commit_write_streams(
+    <pre class="prettyprint"><code>batch_commit_write_streams(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.BatchCommitWriteStreamsRequest,
@@ -346,37 +346,37 @@ becomes available for read operations.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_create_write_stream" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.create_write_stream" class="notranslate">create_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_write_stream(
+    <pre class="prettyprint"><code>create_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.CreateWriteStreamRequest,
@@ -491,7 +491,7 @@ received.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_finalize_write_stream" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.finalize_write_stream" class="notranslate">finalize_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>finalize_write_stream(
+    <pre class="prettyprint"><code>finalize_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.FinalizeWriteStreamRequest,
@@ -588,7 +588,7 @@ the stream. Finalize is not supported on the &#39;_default&#39; stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_flush_rows" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.flush_rows" class="notranslate">flush_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>flush_rows(
+    <pre class="prettyprint"><code>flush_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.FlushRowsRequest, dict
@@ -690,7 +690,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -733,7 +733,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -776,7 +776,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -819,7 +819,7 @@ BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -893,7 +893,7 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_get_write_stream" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.get_write_stream" class="notranslate">get_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_write_stream(
+    <pre class="prettyprint"><code>get_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1.types.storage.GetWriteStreamRequest, dict
@@ -988,55 +988,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_parse_write_stream_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.parse_write_stream_path" class="notranslate">parse_write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_write_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_write_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a write_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_table_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_write_BigQueryWriteClient_write_stream_path" data-uid="google.cloud.bigquery_storage_v1.services.big_query_write.BigQueryWriteClient.write_stream_path" class="notranslate">write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified write_stream string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AppendRowsRequest.ProtoData.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AppendRowsRequest.ProtoData.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ProtoData(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ProtoData(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>ProtoData contains the data rows and schema when constructing
 append requests.</p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AppendRowsRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AppendRowsRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AppendRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>AppendRows</code>.</p>
 <p>Due to the nature of AppendRows being a bidirectional streaming RPC,
@@ -93,7 +93,7 @@ opened/reopened.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_types_AppendRowsRequest_ProtoData" data-uid="google.cloud.bigquery_storage_v1.types.AppendRowsRequest.ProtoData" class="notranslate">ProtoData</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ProtoData(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ProtoData(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>ProtoData contains the data rows and schema when constructing
 append requests.</p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AppendRowsResponse.AppendResult.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AppendRowsResponse.AppendResult.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendResult(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AppendResult(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>AppendResult is returned for successful append requests.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AppendRowsResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AppendRowsResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AppendRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Response message for <code>AppendRows</code>.</p>
 <p>This message has <code>oneof</code>_ fields (mutually exclusive fields).
@@ -97,7 +97,7 @@ members.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_types_AppendRowsResponse_AppendResult" data-uid="google.cloud.bigquery_storage_v1.types.AppendRowsResponse.AppendResult" class="notranslate">AppendResult</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendResult(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AppendResult(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>AppendResult is returned for successful append requests.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ArrowRecordBatch.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ArrowRecordBatch.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ArrowRecordBatch(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ArrowRecordBatch(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Arrow RecordBatch.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ArrowSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ArrowSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ArrowSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ArrowSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Arrow schema as specified in
 <a href="https://arrow.apache.org/docs/python/api/datatypes.html">https://arrow.apache.org/docs/python/api/datatypes.html</a> and

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.CompressionCodec.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.CompressionCodec.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>CompressionCodec(value)</code></pre>
+    <pre class="prettyprint"><code>CompressionCodec(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Compression codec&#39;s supported by Arrow.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ArrowSerializationOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ArrowSerializationOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Contains options specific to Arrow Serialization.</p>
 </div>
@@ -48,7 +48,7 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_types_ArrowSerializationOptions_CompressionCodec" data-uid="google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.CompressionCodec" class="notranslate">CompressionCodec</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>CompressionCodec(value)</code></pre>
+    <pre class="prettyprint"><code>CompressionCodec(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Compression codec&#39;s supported by Arrow.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AvroRows.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AvroRows.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AvroRows(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AvroRows(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Avro rows.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AvroSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.AvroSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AvroSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AvroSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Avro schema.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.BatchCommitWriteStreamsRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.BatchCommitWriteStreamsRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BatchCommitWriteStreamsRequest(
+    <pre class="prettyprint"><code>BatchCommitWriteStreamsRequest(
     mapping=None, *, ignore_unknown_fields=False, **kwargs
 )</code></pre>
   </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.BatchCommitWriteStreamsResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.BatchCommitWriteStreamsResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BatchCommitWriteStreamsResponse(
+    <pre class="prettyprint"><code>BatchCommitWriteStreamsResponse(
     mapping=None, *, ignore_unknown_fields=False, **kwargs
 )</code></pre>
   </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.CreateReadSessionRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.CreateReadSessionRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>CreateReadSessionRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>CreateReadSessionRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>CreateReadSession</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.CreateWriteStreamRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.CreateWriteStreamRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>CreateWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>CreateWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>CreateWriteStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.DataFormat.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.DataFormat.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>DataFormat(value)</code></pre>
+    <pre class="prettyprint"><code>DataFormat(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Data format for input or output data.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.FinalizeWriteStreamRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.FinalizeWriteStreamRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>FinalizeWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>FinalizeWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for invoking <code>FinalizeWriteStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.FinalizeWriteStreamResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.FinalizeWriteStreamResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>FinalizeWriteStreamResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>FinalizeWriteStreamResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Response message for <code>FinalizeWriteStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.FlushRowsRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.FlushRowsRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>FlushRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>FlushRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>FlushRows</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.FlushRowsResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.FlushRowsResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>FlushRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>FlushRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Respond message for <code>FlushRows</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.GetWriteStreamRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.GetWriteStreamRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>GetWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>GetWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>GetWriteStreamRequest</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ProtoRows.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ProtoRows.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ProtoRows(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ProtoRows(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <table class="responsive">
     <tbody>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ProtoSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ProtoSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ProtoSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ProtoSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>ProtoSchema describes the schema of the serialized protocol
 buffer data rows.</p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadRowsRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadRowsRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>ReadRows</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadRowsResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadRowsResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Response from calling <code>ReadRows</code> may include row data, progress
 and throttling information.</p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadSession.TableModifiers.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadSession.TableModifiers.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableModifiers(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableModifiers(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Additional attributes when reading a table.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Options dictating how we read a table.</p>
 <p>.. _oneof: <a href="https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields">https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields</a></p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadSession.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadSession.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadSession(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ReadSession(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Information about the ReadSession.</p>
 <p>This message has <code>oneof</code>_ fields (mutually exclusive fields).
@@ -146,13 +146,13 @@ members.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_types_ReadSession_TableModifiers" data-uid="google.cloud.bigquery_storage_v1.types.ReadSession.TableModifiers" class="notranslate">TableModifiers</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableModifiers(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableModifiers(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Additional attributes when reading a table.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_types_ReadSession_TableReadOptions" data-uid="google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions" class="notranslate">TableReadOptions</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Options dictating how we read a table.</p>
 <p>.. _oneof: <a href="https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields">https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields</a></p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadStream.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ReadStream.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadStream(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ReadStream(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Information about a single stream that gets data out of the storage
 system. Most of the information about <code>ReadStream</code> instances is

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.SplitReadStreamRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.SplitReadStreamRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>SplitReadStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>SplitReadStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>SplitReadStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>SplitReadStreamResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>SplitReadStreamResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Response message for <code>SplitReadStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.StorageError.StorageErrorCode.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.StorageError.StorageErrorCode.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>StorageErrorCode(value)</code></pre>
+    <pre class="prettyprint"><code>StorageErrorCode(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Error code for <code>StorageError</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.StorageError.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.StorageError.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>StorageError(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>StorageError(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Structured custom BigQuery Storage error message. The error
 can be attached as error details in the returned rpc Status. In
@@ -67,7 +67,7 @@ text strings.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_types_StorageError_StorageErrorCode" data-uid="google.cloud.bigquery_storage_v1.types.StorageError.StorageErrorCode" class="notranslate">StorageErrorCode</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>StorageErrorCode(value)</code></pre>
+    <pre class="prettyprint"><code>StorageErrorCode(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Error code for <code>StorageError</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.StreamStats.Progress.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.StreamStats.Progress.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Progress(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>Progress(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <table class="responsive">
     <tbody>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.StreamStats.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.StreamStats.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>StreamStats(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>StreamStats(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Estimated stream statistics for a given read Stream.</p>
 </div>
@@ -48,7 +48,7 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_types_StreamStats_Progress" data-uid="google.cloud.bigquery_storage_v1.types.StreamStats.Progress" class="notranslate">Progress</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Progress(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>Progress(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
 </article>
     </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.TableFieldSchema.Mode.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.TableFieldSchema.Mode.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Mode(value)</code></pre>
+    <pre class="prettyprint"><code>Mode(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>API documentation for <code>bigquery_storage_v1.types.TableFieldSchema.Mode</code> class.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.TableFieldSchema.Type.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.TableFieldSchema.Type.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Type(value)</code></pre>
+    <pre class="prettyprint"><code>Type(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>API documentation for <code>bigquery_storage_v1.types.TableFieldSchema.Type</code> class.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.TableFieldSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.TableFieldSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableFieldSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableFieldSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>TableFieldSchema defines a single field/column within a table
 schema.</p>
@@ -146,13 +146,13 @@ schema.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_types_TableFieldSchema_Mode" data-uid="google.cloud.bigquery_storage_v1.types.TableFieldSchema.Mode" class="notranslate">Mode</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Mode(value)</code></pre>
+    <pre class="prettyprint"><code>Mode(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>API documentation for <code>bigquery_storage_v1.types.TableFieldSchema.Mode</code> class.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_types_TableFieldSchema_Type" data-uid="google.cloud.bigquery_storage_v1.types.TableFieldSchema.Type" class="notranslate">Type</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Type(value)</code></pre>
+    <pre class="prettyprint"><code>Type(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>API documentation for <code>bigquery_storage_v1.types.TableFieldSchema.Type</code> class.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.TableSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.TableSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Schema of a table.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ThrottleState.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.ThrottleState.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ThrottleState(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ThrottleState(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Information on if the current connection is being throttled.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.WriteStream.Type.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.WriteStream.Type.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Type(value)</code></pre>
+    <pre class="prettyprint"><code>Type(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Type enum of the stream.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.WriteStream.WriteMode.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.WriteStream.WriteMode.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>WriteMode(value)</code></pre>
+    <pre class="prettyprint"><code>WriteMode(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Mode enum of the stream.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.WriteStream.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1.types.WriteStream.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>WriteStream(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>WriteStream(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Information about a single stream that gets data inside the
 storage system.</p>
@@ -97,13 +97,13 @@ storage system.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_types_WriteStream_Type" data-uid="google.cloud.bigquery_storage_v1.types.WriteStream.Type" class="notranslate">Type</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Type(value)</code></pre>
+    <pre class="prettyprint"><code>Type(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Type enum of the stream.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_types_WriteStream_WriteMode" data-uid="google.cloud.bigquery_storage_v1.types.WriteStream.WriteMode" class="notranslate">WriteMode</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>WriteMode(value)</code></pre>
+    <pre class="prettyprint"><code>WriteMode(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Mode enum of the stream.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Client for interacting with BigQuery Storage API.</p>
 <p>The BigQuery storage API can be used to read data stored in BigQuery.</p>
@@ -49,7 +49,7 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient" class="notranslate">BigQueryReadClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query read client.</p>
 </div>
@@ -121,7 +121,7 @@
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient___exit__" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.__exit__" class="notranslate">__exit__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__exit__(type, value, traceback)</code></pre>
+    <pre class="prettyprint"><code>__exit__(type, value, traceback)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Releases underlying transport&#39;s resources.</p>
 <p>.. warning::
@@ -131,37 +131,37 @@
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_create_read_session" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.create_read_session" class="notranslate">create_read_session</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_read_session(
+    <pre class="prettyprint"><code>create_read_session(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.CreateReadSessionRequest,
@@ -300,7 +300,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -343,7 +343,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -386,7 +386,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -429,7 +429,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -503,55 +503,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_parse_read_session_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.parse_read_session_path" class="notranslate">parse_read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_session_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_session_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_session path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_parse_read_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.parse_read_stream_path" class="notranslate">parse_read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_read_rows" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.read_rows" class="notranslate">read_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_rows(
+    <pre class="prettyprint"><code>read_rows(
     name,
     offset=0,
     retry=_MethodDefault._DEFAULT_VALUE,
@@ -707,19 +707,19 @@ read_rows_stream = client.read_rows(stream.name)</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_read_session_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.read_session_path" class="notranslate">read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_session_path(project: str, location: str, session: str)</code></pre>
+    <pre class="prettyprint"><code>read_session_path(project: str, location: str, session: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_session string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_read_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.read_stream_path" class="notranslate">read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_stream string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_split_read_stream" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.split_read_stream" class="notranslate">split_read_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>split_read_stream(
+    <pre class="prettyprint"><code>split_read_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.SplitReadStreamRequest,
@@ -800,7 +800,7 @@ once the streams have been read to completion.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Write API.
 The Write API can be used to write data to BigQuery.</p>
@@ -49,7 +49,7 @@ The Write API can be used to write data to BigQuery.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient" class="notranslate">BigQueryWriteClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query write client.</p>
 </div>
@@ -121,7 +121,7 @@ The Write API can be used to write data to BigQuery.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient___exit__" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.__exit__" class="notranslate">__exit__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__exit__(type, value, traceback)</code></pre>
+    <pre class="prettyprint"><code>__exit__(type, value, traceback)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Releases underlying transport&#39;s resources.</p>
 <p>.. warning::
@@ -131,7 +131,7 @@ The Write API can be used to write data to BigQuery.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_append_rows" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.append_rows" class="notranslate">append_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>append_rows(
+    <pre class="prettyprint"><code>append_rows(
     requests: typing.Optional[
         typing.Iterator[
             google.cloud.bigquery_storage_v1beta2.types.storage.AppendRowsRequest
@@ -232,7 +232,7 @@ available for read operations after the stream is committed.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_batch_commit_write_streams" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.batch_commit_write_streams" class="notranslate">batch_commit_write_streams</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>batch_commit_write_streams(
+    <pre class="prettyprint"><code>batch_commit_write_streams(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.BatchCommitWriteStreamsRequest,
@@ -332,37 +332,37 @@ operations.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_create_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.create_write_stream" class="notranslate">create_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_write_stream(
+    <pre class="prettyprint"><code>create_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.CreateWriteStreamRequest,
@@ -477,7 +477,7 @@ received.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_finalize_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.finalize_write_stream" class="notranslate">finalize_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>finalize_write_stream(
+    <pre class="prettyprint"><code>finalize_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.FinalizeWriteStreamRequest,
@@ -574,7 +574,7 @@ the stream. Finalize is not supported on the &#39;_default&#39; stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_flush_rows" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.flush_rows" class="notranslate">flush_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>flush_rows(
+    <pre class="prettyprint"><code>flush_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.FlushRowsRequest, dict
@@ -674,7 +674,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -717,7 +717,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -760,7 +760,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -803,7 +803,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -877,7 +877,7 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_get_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.get_write_stream" class="notranslate">get_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_write_stream(
+    <pre class="prettyprint"><code>get_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.GetWriteStreamRequest,
@@ -973,55 +973,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_parse_write_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.parse_write_stream_path" class="notranslate">parse_write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_write_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_write_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a write_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryWriteClient_write_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.write_stream_path" class="notranslate">write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified write_stream string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.client.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.client.html
@@ -18,14 +18,14 @@
   </h2>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.html">BigQueryReadClient</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Client for interacting with BigQuery Storage API.</p>
 <p>The BigQuery storage API can be used to read data stored in BigQuery.</p>
 </div>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1beta2.client.BigQueryWriteClient.html">BigQueryWriteClient</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>BigQuery Write API.
 The Write API can be used to write data to BigQuery.</p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Read API.
 The Read API can be used to read data from BigQuery.
@@ -49,7 +49,7 @@ use Write API at the same time.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient" class="notranslate">BigQueryReadAsyncClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query read client.</p>
 </div>
@@ -111,37 +111,37 @@ use Write API at the same time.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_create_read_session" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.create_read_session" class="notranslate">create_read_session</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_read_session(
+    <pre class="prettyprint"><code>create_read_session(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.CreateReadSessionRequest,
@@ -280,7 +280,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -323,7 +323,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -366,7 +366,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -409,7 +409,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -483,61 +483,61 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_get_transport_class" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.get_transport_class" class="notranslate">get_transport_class</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_transport_class()</code></pre>
+    <pre class="prettyprint"><code>get_transport_class()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns an appropriate transport class.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_parse_read_session_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.parse_read_session_path" class="notranslate">parse_read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_session_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_session_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_session path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_parse_read_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.parse_read_stream_path" class="notranslate">parse_read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_read_rows" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.read_rows" class="notranslate">read_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_rows(
+    <pre class="prettyprint"><code>read_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.ReadRowsRequest, dict
@@ -649,19 +649,19 @@ reflecting the current state of the stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_read_session_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.read_session_path" class="notranslate">read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_session_path(project: str, location: str, session: str)</code></pre>
+    <pre class="prettyprint"><code>read_session_path(project: str, location: str, session: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_session string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_read_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.read_stream_path" class="notranslate">read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_stream string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_split_read_stream" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.split_read_stream" class="notranslate">split_read_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>split_read_stream(
+    <pre class="prettyprint"><code>split_read_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.SplitReadStreamRequest,
@@ -742,7 +742,7 @@ once the streams have been read to completion.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Read API.
 The Read API can be used to read data from BigQuery.
@@ -49,7 +49,7 @@ use Write API at the same time.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient" class="notranslate">BigQueryReadClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryReadClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_read.transports.base.BigQueryReadTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query read client.</p>
 </div>
@@ -121,7 +121,7 @@ use Write API at the same time.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient___exit__" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.__exit__" class="notranslate">__exit__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__exit__(type, value, traceback)</code></pre>
+    <pre class="prettyprint"><code>__exit__(type, value, traceback)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Releases underlying transport&#39;s resources.</p>
 <p>.. warning::
@@ -131,37 +131,37 @@ use Write API at the same time.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_create_read_session" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.create_read_session" class="notranslate">create_read_session</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_read_session(
+    <pre class="prettyprint"><code>create_read_session(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.CreateReadSessionRequest,
@@ -300,7 +300,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -343,7 +343,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -386,7 +386,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -429,7 +429,7 @@ caller.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -503,55 +503,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_parse_read_session_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.parse_read_session_path" class="notranslate">parse_read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_session_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_session_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_session path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_parse_read_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.parse_read_stream_path" class="notranslate">parse_read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_read_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_read_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a read_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_read_rows" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.read_rows" class="notranslate">read_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_rows(
+    <pre class="prettyprint"><code>read_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.ReadRowsRequest, dict
@@ -663,19 +663,19 @@ reflecting the current state of the stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_read_session_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.read_session_path" class="notranslate">read_session_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_session_path(project: str, location: str, session: str)</code></pre>
+    <pre class="prettyprint"><code>read_session_path(project: str, location: str, session: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_session string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_read_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.read_stream_path" class="notranslate">read_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>read_stream_path(project: str, location: str, session: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified read_stream string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_split_read_stream" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.split_read_stream" class="notranslate">split_read_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>split_read_stream(
+    <pre class="prettyprint"><code>split_read_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.SplitReadStreamRequest,
@@ -756,7 +756,7 @@ once the streams have been read to completion.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Write API.
 The Write API can be used to write data to BigQuery.</p>
@@ -47,7 +47,7 @@ The Write API can be used to write data to BigQuery.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient" class="notranslate">BigQueryWriteAsyncClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteAsyncClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport] = 'grpc_asyncio', client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query write client.</p>
 </div>
@@ -109,7 +109,7 @@ The Write API can be used to write data to BigQuery.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_append_rows" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.append_rows" class="notranslate">append_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>append_rows(
+    <pre class="prettyprint"><code>append_rows(
     requests: typing.Optional[
         typing.AsyncIterator[
             google.cloud.bigquery_storage_v1beta2.types.storage.AppendRowsRequest
@@ -210,7 +210,7 @@ available for read operations after the stream is committed.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_batch_commit_write_streams" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.batch_commit_write_streams" class="notranslate">batch_commit_write_streams</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>batch_commit_write_streams(
+    <pre class="prettyprint"><code>batch_commit_write_streams(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.BatchCommitWriteStreamsRequest,
@@ -310,37 +310,37 @@ operations.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_create_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.create_write_stream" class="notranslate">create_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_write_stream(
+    <pre class="prettyprint"><code>create_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.CreateWriteStreamRequest,
@@ -455,7 +455,7 @@ received.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_finalize_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.finalize_write_stream" class="notranslate">finalize_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>finalize_write_stream(
+    <pre class="prettyprint"><code>finalize_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.FinalizeWriteStreamRequest,
@@ -552,7 +552,7 @@ the stream. Finalize is not supported on the &#39;_default&#39; stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_flush_rows" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.flush_rows" class="notranslate">flush_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>flush_rows(
+    <pre class="prettyprint"><code>flush_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.FlushRowsRequest, dict
@@ -652,7 +652,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -695,7 +695,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -738,7 +738,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -781,7 +781,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -855,13 +855,13 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_get_transport_class" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.get_transport_class" class="notranslate">get_transport_class</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_transport_class()</code></pre>
+    <pre class="prettyprint"><code>get_transport_class()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns an appropriate transport class.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_get_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.get_write_stream" class="notranslate">get_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_write_stream(
+    <pre class="prettyprint"><code>get_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.GetWriteStreamRequest,
@@ -957,55 +957,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_parse_write_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.parse_write_stream_path" class="notranslate">parse_write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_write_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_write_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a write_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_write_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.write_stream_path" class="notranslate">write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified write_stream string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>BigQuery Write API.
 The Write API can be used to write data to BigQuery.</p>
@@ -47,7 +47,7 @@ The Write API can be used to write data to BigQuery.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient" class="notranslate">BigQueryWriteClient</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
+    <pre class="prettyprint"><code>BigQueryWriteClient(*, credentials: typing.Optional[google.auth.credentials.Credentials] = None, transport: typing.Optional[typing.Union[str, google.cloud.bigquery_storage_v1beta2.services.big_query_write.transports.base.BigQueryWriteTransport]] = None, client_options: typing.Optional[google.api_core.client_options.ClientOptions] = None, client_info: google.api_core.gapic_v1.client_info.ClientInfo = &lt;google.api_core.gapic_v1.client_info.ClientInfo object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Instantiates the big query write client.</p>
 </div>
@@ -119,7 +119,7 @@ The Write API can be used to write data to BigQuery.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient___exit__" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.__exit__" class="notranslate">__exit__</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>__exit__(type, value, traceback)</code></pre>
+    <pre class="prettyprint"><code>__exit__(type, value, traceback)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Releases underlying transport&#39;s resources.</p>
 <p>.. warning::
@@ -129,7 +129,7 @@ The Write API can be used to write data to BigQuery.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_append_rows" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.append_rows" class="notranslate">append_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>append_rows(
+    <pre class="prettyprint"><code>append_rows(
     requests: typing.Optional[
         typing.Iterator[
             google.cloud.bigquery_storage_v1beta2.types.storage.AppendRowsRequest
@@ -230,7 +230,7 @@ available for read operations after the stream is committed.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_batch_commit_write_streams" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.batch_commit_write_streams" class="notranslate">batch_commit_write_streams</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>batch_commit_write_streams(
+    <pre class="prettyprint"><code>batch_commit_write_streams(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.BatchCommitWriteStreamsRequest,
@@ -330,37 +330,37 @@ operations.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.common_billing_account_path" class="notranslate">common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_billing_account_path(billing_account: str)</code></pre>
+    <pre class="prettyprint"><code>common_billing_account_path(billing_account: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified billing_account string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.common_folder_path" class="notranslate">common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_folder_path(folder: str)</code></pre>
+    <pre class="prettyprint"><code>common_folder_path(folder: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified folder string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.common_location_path" class="notranslate">common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_location_path(project: str, location: str)</code></pre>
+    <pre class="prettyprint"><code>common_location_path(project: str, location: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified location string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.common_organization_path" class="notranslate">common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_organization_path(organization: str)</code></pre>
+    <pre class="prettyprint"><code>common_organization_path(organization: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified organization string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.common_project_path" class="notranslate">common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>common_project_path(project: str)</code></pre>
+    <pre class="prettyprint"><code>common_project_path(project: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified project string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_create_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.create_write_stream" class="notranslate">create_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>create_write_stream(
+    <pre class="prettyprint"><code>create_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.CreateWriteStreamRequest,
@@ -475,7 +475,7 @@ received.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_finalize_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.finalize_write_stream" class="notranslate">finalize_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>finalize_write_stream(
+    <pre class="prettyprint"><code>finalize_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.FinalizeWriteStreamRequest,
@@ -572,7 +572,7 @@ the stream. Finalize is not supported on the &#39;_default&#39; stream.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_flush_rows" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.flush_rows" class="notranslate">flush_rows</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>flush_rows(
+    <pre class="prettyprint"><code>flush_rows(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.FlushRowsRequest, dict
@@ -672,7 +672,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_from_service_account_file" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.from_service_account_file" class="notranslate">from_service_account_file</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -715,7 +715,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_from_service_account_info" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.from_service_account_info" class="notranslate">from_service_account_info</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_info(info: dict, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     info.</p>
@@ -758,7 +758,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_from_service_account_json" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.from_service_account_json" class="notranslate">from_service_account_json</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
     file.</p>
@@ -801,7 +801,7 @@ _default stream, since it is not BUFFERED.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_get_mtls_endpoint_and_cert_source" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.get_mtls_endpoint_and_cert_source" class="notranslate">get_mtls_endpoint_and_cert_source</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_mtls_endpoint_and_cert_source(
+    <pre class="prettyprint"><code>get_mtls_endpoint_and_cert_source(
     client_options: typing.Optional[
         google.api_core.client_options.ClientOptions
     ] = None,
@@ -875,7 +875,7 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_get_write_stream" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.get_write_stream" class="notranslate">get_write_stream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>get_write_stream(
+    <pre class="prettyprint"><code>get_write_stream(
     request: typing.Optional[
         typing.Union[
             google.cloud.bigquery_storage_v1beta2.types.storage.GetWriteStreamRequest,
@@ -971,55 +971,55 @@ use the default API endpoint.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_parse_common_billing_account_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.parse_common_billing_account_path" class="notranslate">parse_common_billing_account_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_billing_account_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_billing_account_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a billing_account path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_parse_common_folder_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.parse_common_folder_path" class="notranslate">parse_common_folder_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_folder_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_folder_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a folder path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_parse_common_location_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.parse_common_location_path" class="notranslate">parse_common_location_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_location_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_location_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a location path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_parse_common_organization_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.parse_common_organization_path" class="notranslate">parse_common_organization_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_organization_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_organization_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a organization path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_parse_common_project_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.parse_common_project_path" class="notranslate">parse_common_project_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_common_project_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_common_project_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parse a project path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_parse_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.parse_table_path" class="notranslate">parse_table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_table_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_table_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a table path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_parse_write_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.parse_write_stream_path" class="notranslate">parse_write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>parse_write_stream_path(path: str)</code></pre>
+    <pre class="prettyprint"><code>parse_write_stream_path(path: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Parses a write_stream path into its component segments.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_table_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.table_path" class="notranslate">table_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>table_path(project: str, dataset: str, table: str)</code></pre>
+    <pre class="prettyprint"><code>table_path(project: str, dataset: str, table: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified table string.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_write_stream_path" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.write_stream_path" class="notranslate">write_stream_path</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
+    <pre class="prettyprint"><code>write_stream_path(project: str, dataset: str, table: str, stream: str)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Returns a fully-qualified write_stream string.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.ProtoData.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.ProtoData.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ProtoData(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ProtoData(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Proto schema and data.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AppendRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>AppendRows</code>.</p>
 <p>.. _oneof: <a href="https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields">https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields</a></p>
@@ -85,7 +85,7 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_AppendRowsRequest_ProtoData" data-uid="google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.ProtoData" class="notranslate">ProtoData</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ProtoData(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ProtoData(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Proto schema and data.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AppendRowsResponse.AppendResult.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AppendRowsResponse.AppendResult.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendResult(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AppendResult(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>AppendResult is returned for successful append requests.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AppendRowsResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AppendRowsResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AppendRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Response message for <code>AppendRows</code>.</p>
 <p>This message has <code>oneof</code>_ fields (mutually exclusive fields).
@@ -97,7 +97,7 @@ members.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_AppendRowsResponse_AppendResult" data-uid="google.cloud.bigquery_storage_v1beta2.types.AppendRowsResponse.AppendResult" class="notranslate">AppendResult</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendResult(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AppendResult(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>AppendResult is returned for successful append requests.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ArrowRecordBatch.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ArrowRecordBatch.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ArrowRecordBatch(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ArrowRecordBatch(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Arrow RecordBatch.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ArrowSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ArrowSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ArrowSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ArrowSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Arrow schema as specified in
 <a href="https://arrow.apache.org/docs/python/api/datatypes.html">https://arrow.apache.org/docs/python/api/datatypes.html</a> and

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ArrowSerializationOptions.Format.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ArrowSerializationOptions.Format.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Format(value)</code></pre>
+    <pre class="prettyprint"><code>Format(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>The IPC format to use when serializing Arrow streams.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ArrowSerializationOptions.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ArrowSerializationOptions.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ArrowSerializationOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ArrowSerializationOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Contains options specific to Arrow Serialization.</p>
 </div>
@@ -47,7 +47,7 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_ArrowSerializationOptions_Format" data-uid="google.cloud.bigquery_storage_v1beta2.types.ArrowSerializationOptions.Format" class="notranslate">Format</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Format(value)</code></pre>
+    <pre class="prettyprint"><code>Format(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>The IPC format to use when serializing Arrow streams.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AvroRows.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AvroRows.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AvroRows(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AvroRows(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Avro rows.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AvroSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.AvroSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AvroSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>AvroSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Avro schema.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.BatchCommitWriteStreamsRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.BatchCommitWriteStreamsRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BatchCommitWriteStreamsRequest(
+    <pre class="prettyprint"><code>BatchCommitWriteStreamsRequest(
     mapping=None, *, ignore_unknown_fields=False, **kwargs
 )</code></pre>
   </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.BatchCommitWriteStreamsResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.BatchCommitWriteStreamsResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>BatchCommitWriteStreamsResponse(
+    <pre class="prettyprint"><code>BatchCommitWriteStreamsResponse(
     mapping=None, *, ignore_unknown_fields=False, **kwargs
 )</code></pre>
   </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.CreateReadSessionRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.CreateReadSessionRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>CreateReadSessionRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>CreateReadSessionRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>CreateReadSession</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.CreateWriteStreamRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.CreateWriteStreamRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>CreateWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>CreateWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>CreateWriteStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.DataFormat.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.DataFormat.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>DataFormat(value)</code></pre>
+    <pre class="prettyprint"><code>DataFormat(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Data format for input or output data.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.FinalizeWriteStreamRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.FinalizeWriteStreamRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>FinalizeWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>FinalizeWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for invoking <code>FinalizeWriteStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.FinalizeWriteStreamResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.FinalizeWriteStreamResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>FinalizeWriteStreamResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>FinalizeWriteStreamResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Response message for <code>FinalizeWriteStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.FlushRowsRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.FlushRowsRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>FlushRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>FlushRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>FlushRows</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.FlushRowsResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.FlushRowsResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>FlushRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>FlushRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Respond message for <code>FlushRows</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.GetWriteStreamRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.GetWriteStreamRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>GetWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>GetWriteStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>GetWriteStreamRequest</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ProtoRows.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ProtoRows.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ProtoRows(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ProtoRows(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <table class="responsive">
     <tbody>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ProtoSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ProtoSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ProtoSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ProtoSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>ProtoSchema describes the schema of the serialized protocol
 buffer data rows.</p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadRowsRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadRowsRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>ReadRows</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadRowsResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadRowsResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ReadRowsResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Response from calling <code>ReadRows</code> may include row data, progress
 and throttling information.</p>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadSession.TableModifiers.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadSession.TableModifiers.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableModifiers(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableModifiers(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Additional attributes when reading a table.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadSession.TableReadOptions.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadSession.TableReadOptions.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Options dictating how we read a table.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadSession.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadSession.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadSession(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ReadSession(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Information about the ReadSession.</p>
 <p>This message has <code>oneof</code>_ fields (mutually exclusive fields).
@@ -134,13 +134,13 @@ members.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_ReadSession_TableModifiers" data-uid="google.cloud.bigquery_storage_v1beta2.types.ReadSession.TableModifiers" class="notranslate">TableModifiers</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableModifiers(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableModifiers(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Additional attributes when reading a table.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_ReadSession_TableReadOptions" data-uid="google.cloud.bigquery_storage_v1beta2.types.ReadSession.TableReadOptions" class="notranslate">TableReadOptions</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Options dictating how we read a table.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadStream.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ReadStream.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ReadStream(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ReadStream(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Information about a single stream that gets data out of the storage
 system. Most of the information about <code>ReadStream</code> instances is

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.SplitReadStreamRequest.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.SplitReadStreamRequest.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>SplitReadStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>SplitReadStreamRequest(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Request message for <code>SplitReadStream</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.SplitReadStreamResponse.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.SplitReadStreamResponse.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>SplitReadStreamResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>SplitReadStreamResponse(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <table class="responsive">
     <tbody>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.StorageError.StorageErrorCode.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.StorageError.StorageErrorCode.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>StorageErrorCode(value)</code></pre>
+    <pre class="prettyprint"><code>StorageErrorCode(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Error code for <code>StorageError</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.StorageError.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.StorageError.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>StorageError(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>StorageError(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Structured custom BigQuery Storage error message. The error
 can be attached as error details in the returned rpc Status. In
@@ -67,7 +67,7 @@ text strings.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_StorageError_StorageErrorCode" data-uid="google.cloud.bigquery_storage_v1beta2.types.StorageError.StorageErrorCode" class="notranslate">StorageErrorCode</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>StorageErrorCode(value)</code></pre>
+    <pre class="prettyprint"><code>StorageErrorCode(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Error code for <code>StorageError</code>.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.StreamStats.Progress.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.StreamStats.Progress.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Progress(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>Progress(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <table class="responsive">
     <tbody>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.StreamStats.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.StreamStats.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>StreamStats(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>StreamStats(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Estimated stream statistics for a given Stream.</p>
 </div>
@@ -48,7 +48,7 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_StreamStats_Progress" data-uid="google.cloud.bigquery_storage_v1beta2.types.StreamStats.Progress" class="notranslate">Progress</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Progress(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>Progress(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
 </article>
     </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.Mode.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.Mode.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Mode(value)</code></pre>
+    <pre class="prettyprint"><code>Mode(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>API documentation for <code>bigquery_storage_v1beta2.types.TableFieldSchema.Mode</code> class.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.Type.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.Type.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Type(value)</code></pre>
+    <pre class="prettyprint"><code>Type(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>API documentation for <code>bigquery_storage_v1beta2.types.TableFieldSchema.Type</code> class.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableFieldSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableFieldSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>A field in TableSchema</p>
 </div>
@@ -85,13 +85,13 @@
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_TableFieldSchema_Mode" data-uid="google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.Mode" class="notranslate">Mode</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Mode(value)</code></pre>
+    <pre class="prettyprint"><code>Mode(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>API documentation for <code>bigquery_storage_v1beta2.types.TableFieldSchema.Mode</code> class.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_TableFieldSchema_Type" data-uid="google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.Type" class="notranslate">Type</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Type(value)</code></pre>
+    <pre class="prettyprint"><code>Type(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>API documentation for <code>bigquery_storage_v1beta2.types.TableFieldSchema.Type</code> class.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.TableSchema.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.TableSchema.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>TableSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>TableSchema(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Schema of a table</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ThrottleState.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.ThrottleState.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>ThrottleState(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>ThrottleState(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Information on if the current connection is being throttled.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.WriteStream.Type.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.WriteStream.Type.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Type(value)</code></pre>
+    <pre class="prettyprint"><code>Type(value)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Type enum of the stream.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.WriteStream.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.types.WriteStream.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>WriteStream(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
+    <pre class="prettyprint"><code>WriteStream(mapping=None, *, ignore_unknown_fields=False, **kwargs)</code></pre>
   </div>
   <div class="markdown level0 summary"><p>Information about a single stream that gets data inside the
 storage system.</p>
@@ -89,7 +89,7 @@ storage system.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_types_WriteStream_Type" data-uid="google.cloud.bigquery_storage_v1beta2.types.WriteStream.Type" class="notranslate">Type</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>Type(value)</code></pre>
+    <pre class="prettyprint"><code>Type(value)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Type enum of the stream.</p>
 </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsFuture(
+    <pre class="prettyprint"><code>AppendRowsFuture(
     manager: google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream,
 )</code></pre>
   </div>
@@ -36,7 +36,7 @@ methods in this library.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_add_done_callback" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.add_done_callback" class="notranslate">add_done_callback</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>add_done_callback(fn)</code></pre>
+    <pre class="prettyprint"><code>add_done_callback(fn)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Add a callback to be executed when the operation is complete.</p>
 <p>If the operation is not already complete, this will start a helper
@@ -65,7 +65,7 @@ thread to poll for the status of the operation in the background.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_cancel" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.cancel" class="notranslate">cancel</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>cancel()</code></pre>
+    <pre class="prettyprint"><code>cancel()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Stops pulling messages and shutdowns the background thread consuming
  messages.</p>
@@ -75,20 +75,20 @@ immediately. To block until the background stream is terminated, call
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_cancelled" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.cancelled" class="notranslate">cancelled</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>cancelled()</code></pre>
+    <pre class="prettyprint"><code>cancelled()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>:returns: <code>True</code> if the write stream has been cancelled.
 :rtype: bool</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_done" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.done" class="notranslate">done</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>done(retry: typing.Optional[google.api_core.retry.Retry] = None)</code></pre>
+    <pre class="prettyprint"><code>done(retry: typing.Optional[google.api_core.retry.Retry] = None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Check the status of the future.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_exception" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.exception" class="notranslate">exception</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>exception(timeout=None)</code></pre>
+    <pre class="prettyprint"><code>exception(timeout=None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Get the exception from the operation, blocking if necessary.</p>
 </div>
@@ -130,7 +130,7 @@ immediately. To block until the background stream is terminated, call
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_result" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.result" class="notranslate">result</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>result(timeout=None, retry=&lt;google.api_core.retry.Retry object&gt;)</code></pre>
+    <pre class="prettyprint"><code>result(timeout=None, retry=&lt;google.api_core.retry.Retry object&gt;)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Get the result of the operation, blocking if necessary.</p>
 </div>
@@ -187,13 +187,13 @@ immediately. To block until the background stream is terminated, call
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_running" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.running" class="notranslate">running</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>running()</code></pre>
+    <pre class="prettyprint"><code>running()</code></pre>
   </div>
   <div class="markdown level1 summary"><p>True if the operation is currently running.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_set_exception" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.set_exception" class="notranslate">set_exception</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>set_exception(exception)</code></pre>
+    <pre class="prettyprint"><code>set_exception(exception)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Set the result of the future as being the given exception.</p>
 <p>Do not use this method, it should only be used internally by the library and its
@@ -201,7 +201,7 @@ unit tests.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsFuture_set_result" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.set_result" class="notranslate">set_result</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>set_result(result)</code></pre>
+    <pre class="prettyprint"><code>set_result(result)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Set the return value of work associated with the future.</p>
 <p>Do not use this method, it should only be used internally by the library and its

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream.html
@@ -12,7 +12,7 @@
   
   
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsStream(
+    <pre class="prettyprint"><code>AppendRowsStream(
     client: google.cloud.bigquery_storage_v1beta2.services.big_query_write.client.BigQueryWriteClient,
     initial_request_template: google.cloud.bigquery_storage_v1beta2.types.storage.AppendRowsRequest,
     metadata: typing.Sequence[typing.Tuple[str, str]] = (),
@@ -37,7 +37,7 @@ just that it stopped getting new messages.</p>
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsStream" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream" class="notranslate">AppendRowsStream</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsStream(
+    <pre class="prettyprint"><code>AppendRowsStream(
     client: google.cloud.bigquery_storage_v1beta2.services.big_query_write.client.BigQueryWriteClient,
     initial_request_template: google.cloud.bigquery_storage_v1beta2.types.storage.AppendRowsRequest,
     metadata: typing.Sequence[typing.Tuple[str, str]] = (),
@@ -47,7 +47,7 @@ just that it stopped getting new messages.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsStream_add_close_callback" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream.add_close_callback" class="notranslate">add_close_callback</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>add_close_callback(callback: typing.Callable)</code></pre>
+    <pre class="prettyprint"><code>add_close_callback(callback: typing.Callable)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Schedules a callable when the manager closes.</p>
 </div>
@@ -74,14 +74,14 @@ just that it stopped getting new messages.</p>
   </table>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsStream_close" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream.close" class="notranslate">close</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>close(reason: typing.Optional[Exception] = None)</code></pre>
+    <pre class="prettyprint"><code>close(reason: typing.Optional[Exception] = None)</code></pre>
   </div>
   <div class="markdown level1 summary"><p>Stop consuming messages and shutdown all helper threads.</p>
 <p>This method is idempotent. Additional calls will have no effect.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1beta2_writer_AppendRowsStream_send" data-uid="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream.send" class="notranslate">send</h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>send(
+    <pre class="prettyprint"><code>send(
     request: google.cloud.bigquery_storage_v1beta2.types.storage.AppendRowsRequest,
 )</code></pre>
   </div>

--- a/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.writer.html
+++ b/testdata/goldens/python/google.cloud.bigquery_storage_v1beta2.writer.html
@@ -17,7 +17,7 @@
   </h2>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsFuture.html">AppendRowsFuture</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsFuture(
+    <pre class="prettyprint"><code>AppendRowsFuture(
     manager: google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream,
 )</code></pre>
   </div>
@@ -29,7 +29,7 @@ methods in this library.</p>
 </div>
   <h3><a class="xref" href="google.cloud.bigquery_storage_v1beta2.writer.AppendRowsStream.html">AppendRowsStream</a></h3>
   <div class="codewrapper">
-    <pre class="prettyprint wrap-code"><code>AppendRowsStream(
+    <pre class="prettyprint"><code>AppendRowsStream(
     client: google.cloud.bigquery_storage_v1beta2.services.big_query_write.client.BigQueryWriteClient,
     initial_request_template: google.cloud.bigquery_storage_v1beta2.types.storage.AppendRowsRequest,
     metadata: typing.Sequence[typing.Tuple[str, str]] = (),

--- a/third_party/docfx/templates/devsite/UniversalReference.common.js
+++ b/third_party/docfx/templates/devsite/UniversalReference.common.js
@@ -123,11 +123,6 @@ function handleItem(vm, gitContribute, gitUrlPattern) {
     normalizeLanguageValuePairs(vm.inheritance).forEach(handleInheritance);
   }
 
-  // wrapdeclarationcode is used to automatically line break declaration code
-  if (vm.langs && vm.langs[0] === "python") {
-      vm.wrapdeclarationcode = true;
-  }
-
   common.processSeeAlso(vm);
 
   // id is used as default template's bookmark

--- a/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
@@ -3,7 +3,7 @@
 {{>partials/disclaimer}}
 {{#syntax.content.0}}
 <div class="codewrapper">
-  <pre class="prettyprint{{#wrapdeclarationcode}} wrap-code{{/wrapdeclarationcode}}"><code>{{syntax.content.0.value}}</code></pre>
+  <pre class="prettyprint"><code>{{syntax.content.0.value}}</code></pre>
 </div>
 {{/syntax.content.0}}
 {{#summary}}

--- a/third_party/docfx/templates/devsite/partials/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.tmpl.partial
@@ -21,7 +21,7 @@
 <h3 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}{{#deprecated}} (deprecated){{/deprecated}}</h3>
 {{#syntax.content.0}}
 <div class="codewrapper">
-  <pre class="prettyprint{{#wrapdeclarationcode}} wrap-code{{/wrapdeclarationcode}}"><code>{{syntax.content.0.value}}</code></pre>
+  <pre class="prettyprint"><code>{{syntax.content.0.value}}</code></pre>
 </div>
 {{/syntax.content.0}}
 {{#summary}}

--- a/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
@@ -3,7 +3,7 @@
 {{>partials/disclaimer}}
 {{#syntax.content.0}}
 <div class="codewrapper">
-  <pre class="prettyprint{{#wrapdeclarationcode}} wrap-code{{/wrapdeclarationcode}}"><code>{{syntax.content.0.value}}</code></pre>
+  <pre class="prettyprint"><code>{{syntax.content.0.value}}</code></pre>
 </div>
 {{/syntax.content.0}}
 {{#summary}}

--- a/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
@@ -33,7 +33,7 @@
 {{/inModule}}
 {{#syntax.content.0}}
 <div class="codewrapper">
-  <pre class="prettyprint{{#wrapdeclarationcode}} wrap-code{{/wrapdeclarationcode}}"><code>{{syntax.content.0.value}}</code></pre>
+  <pre class="prettyprint"><code>{{syntax.content.0.value}}</code></pre>
 </div>
 {{/syntax.content.0}}
 {{#syntax.aliasof}}

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -49,7 +49,7 @@
       {{/inTypes}}
       {{#syntax.content.0}}
       <div class="codewrapper">
-        <pre class="prettyprint{{#wrapdeclarationcode}} wrap-code{{/wrapdeclarationcode}}"><code>{{{syntax.content.0.value}}}</code></pre>
+        <pre class="prettyprint"><code>{{{syntax.content.0.value}}}</code></pre>
       </div>
       {{/syntax.content.0}}
       {{#syntax.aliasof}}
@@ -234,7 +234,7 @@
           <h3 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}{{#deprecated}} (deprecated){{/deprecated}}</h3>
           {{#syntax}}
           <div class="codewrapper">
-            <pre class="prettyprint{{#wrapdeclarationcode}} wrap-code{{/wrapdeclarationcode}}"><code>{{{syntax.content.0.value}}}</code></pre>
+            <pre class="prettyprint"><code>{{{syntax.content.0.value}}}</code></pre>
           </div>
           {{/syntax}}
           <div class="markdown level1 summary">{{{summary}}}</div>


### PR DESCRIPTION
wrap-code was set specifically for Python codeblocks, especially for long signatures. However, the code is already well formatted with black's code formatter, (https://github.com/googleapis/sphinx-docfx-yaml/blob/a02026995b454e7d20095504421c17a54ba251c4/docfx_yaml/extension.py#L1283-L1298) and wrap-code removed whitespace that helped with readability, which makes it harder to read.

See relevant template changes on https://github.com/googleapis/doc-pipeline/pull/677/commits/4e56258fe812dbed04bef7817c8280d65855ac8d

Updated goldens and verified that only Python codeblocks are affected.

Fixes b/367426932 (see before/after comparison on it).