### PR TITLE
build: update timeout to 10 hours

### DIFF
--- a/ci/common.cfg
+++ b/ci/common.cfg
@@ -14,8 +14,8 @@
 
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Build timeout set for 72 hours
-timeout_mins: 4320
+# Build timeout set for 10 hours
+timeout_mins: 600
 
 # Use the trampoline script to run in docker.
 build_file: "doc-pipeline/ci/trampoline_v2.sh"


### PR DESCRIPTION
72 hour limit previously was set to account for regenerating all the blobs. Now that we have a lot more blobs to process we will need to increase this limit, and we haven't had to do a regeneration of all the blobs. 10 hours should be good for processing blobs on a regular basis, and most language refreshes for the latest version should still be good with a 10 hour timeout.

We could opt for quicker cycles, but don't anticipate this to be a recurring problem, and could potentially slip through if someone did want to generate for all latest language blobs.

Towards b/443782209.