### PR TITLE
build: fix Dockerfile for docfx

### DIFF
--- a/docfx/Dockerfile
+++ b/docfx/Dockerfile
@@ -12,43 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11-buster
+# Use the official Python 3.12 image based on Debian Bookworm
+FROM python:3.12
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV PATH ${PATH}:/opt/docfx
-
-RUN apt update && \
-    apt -y install gnupg ca-certificates wget zip git apt-transport-https dirmngr
-
-# Install mono with the instructions at:
-# https://www.mono-project.com/download/stable/#download-lin
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-    --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    echo "deb https://download.mono-project.com/repo/debian stable-buster main" \
-    | tee /etc/apt/sources.list.d/mono-official-stable.list && \
-    apt update && \
-    apt install -y mono-complete ca-certificates-mono
-
+# Set environment variables
+# DEBIAN_FRONTEND=noninteractive prevents interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+# DOCFX_VERSION can be overridden at build time
 ARG DOCFX_VERSION=v2.58
 
-# Install docfx.
-RUN mkdir -p /opt/docfx
-RUN wget \
-    https://github.com/dotnet/docfx/releases/download/${DOCFX_VERSION}/docfx.zip \
-    -O /opt/docfx/docfx.zip && \
-    cd /opt/docfx && \
-    unzip docfx.zip
+# Install system dependencies, Mono, and clean up in a single layer
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gnupg \
+        ca-certificates \
+        wget \
+        zip \
+        git \
+        apt-transport-https \
+        dirmngr && \
+    # Add the Mono repository key securely
+    wget -qO - "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF" | gpg --dearmor -o /usr/share/keyrings/mono-official-archive-keyring.gpg && \
+    # Add the Mono repository using the correct name 'stable-buster'
+    echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian stable-buster main" > /etc/apt/sources.list.d/mono-official-stable.list && \
+    # Update package lists and install Mono
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        mono-complete \
+        ca-certificates-mono && \
+    # Clean up to reduce image size
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-# A shell wrapper.
-RUN echo '#!/bin/bash' >> /opt/docfx/docfx && \
-    echo 'exec mono /opt/docfx/docfx.exe $@' >> /opt/docfx/docfx && \
-    chmod 0755 /opt/docfx/docfx
-ENV PATH $PATH:/opt/docfx
+RUN mkdir -p /opt/docfx && \
+    wget https://github.com/dotnet/docfx/releases/download/${DOCFX_VERSION}/docfx.zip -O /opt/docfx/docfx.zip && \
+    unzip /opt/docfx/docfx.zip -d /opt/docfx && \
+    rm /opt/docfx/docfx.zip
 
-# Install gcloud and gsutil.
-RUN mkdir -p /usr/local/gcloud
-RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz \
-    -O /tmp/google-cloud-sdk.tar.gz && \
+# Create a shell wrapper for docfx
+RUN echo '#!/bin/bash' > /opt/docfx/docfx && \
+    echo 'exec mono /opt/docfx/docfx.exe "$@"' >> /opt/docfx/docfx && \
+    chmod +x /opt/docfx/docfx
+
+# Install Google Cloud SDK and clean up in a single layer
+RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz -O /tmp/google-cloud-sdk.tar.gz && \
+    mkdir -p /usr/local/gcloud && \
     tar -xvf /tmp/google-cloud-sdk.tar.gz -C /usr/local/gcloud && \
+    rm /tmp/google-cloud-sdk.tar.gz && \
     /usr/local/gcloud/google-cloud-sdk/install.sh --quiet
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+
+# Set the PATH environment variable to include all new executables
+ENV PATH="${PATH}:/opt/docfx:/usr/local/gcloud/google-cloud-sdk/bin"

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -403,7 +403,7 @@ def build_blobs(blobs: List[storage.Blob]):
     successes = []
     for i, blob in enumerate(blobs):
         try:
-            log.info(f"Processing {i+1} of {len(blobs)}: {blob.name}...")
+            log.info(f"Processing {i + 1} of {len(blobs)}: {blob.name}...")
             if not blob.name.startswith("docfx"):
                 raise ValueError(
                     (

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-flake8==6.0.0
+flake8==6.1.0
 black==24.3.0
 parameterized==0.8.1
 pytest==7.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,9 +94,9 @@ exceptiongroup==1.2.0 \
     --hash=sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14 \
     --hash=sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68
     # via pytest
-flake8==6.0.0 \
-    --hash=sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7 \
-    --hash=sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181
+flake8==6.1.0 \
+    --hash=sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23 \
+    --hash=sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5
     # via -r requirements.in
 iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
@@ -166,13 +166,13 @@ pluggy==1.3.0 \
     --hash=sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12 \
     --hash=sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7
     # via pytest
-pycodestyle==2.10.0 \
-    --hash=sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053 \
-    --hash=sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610
+pycodestyle==2.11.1 \
+    --hash=sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f \
+    --hash=sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67
     # via flake8
-pyflakes==3.0.1 \
-    --hash=sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf \
-    --hash=sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd
+pyflakes==3.1.0 \
+    --hash=sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774 \
+    --hash=sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc
     # via flake8
 pytest==7.2.1 \
     --hash=sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5 \
@@ -180,9 +180,9 @@ pytest==7.2.1 \
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==5.0.0 \
-    --hash=sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652 \
-    --hash=sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857
+pytest-cov==4.0.0 \
+    --hash=sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b \
+    --hash=sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470
     # via -r requirements.in
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \


### PR DESCRIPTION
There was an issue with apt-key and one of the repositories for installations that disappeared: `stable-bookworm Release 404 The specified blob does not exist.`

Fixed the issue and verified locally that the docker image builds and local runs can build again.

Flake needs to be 6.1.0 or higher for docker images with Python 3.12 or higher. Ran into https://stackoverflow.com/questions/77401175/how-to-make-flake8-ignore-syntax-within-strings.

Fixes b/450113730.