### PR TITLE
chore: update Ruby template to include IncludedIn

### DIFF
--- a/testdata/goldens/ruby/Google-Cloud-Vision-V1-ImageAnnotator-Paths.html
+++ b/testdata/goldens/ruby/Google-Cloud-Vision-V1-ImageAnnotator-Paths.html
@@ -21,6 +21,17 @@
       </li>
     </ul>
   </div>
+  <div class="inheritance">
+    <h2>Included In</h2>
+    <ul>
+      <li>
+        <a href="./Google-Cloud-Vision-V1-ImageAnnotator-Client">Google::Cloud::Vision::V1::ImageAnnotator::Client</a>
+      </li>
+      <li>
+        <a href="./Google-Cloud-Vision-V1-ImageAnnotator-Paths">Google::Cloud::Vision::V1::ImageAnnotator::Paths</a>
+      </li>
+    </ul>
+  </div>
   <h2 id="methods">Methods
   </h2>
   <h3 id="Google__Cloud__Vision__V1__ImageAnnotator__Paths_product_set_path_instance_" data-uid="Google::Cloud::Vision::V1::ImageAnnotator::Paths#product_set_path(instance)" class="notranslate">#product_set_path</h3>

--- a/testdata/goldens/ruby/Google-Cloud-Vision-V1-ProductSearch-Paths.html
+++ b/testdata/goldens/ruby/Google-Cloud-Vision-V1-ProductSearch-Paths.html
@@ -21,6 +21,17 @@
       </li>
     </ul>
   </div>
+  <div class="inheritance">
+    <h2>Included In</h2>
+    <ul>
+      <li>
+        <a href="./Google-Cloud-Vision-V1-ProductSearch-Client">Google::Cloud::Vision::V1::ProductSearch::Client</a>
+      </li>
+      <li>
+        <a href="./Google-Cloud-Vision-V1-ProductSearch-Paths">Google::Cloud::Vision::V1::ProductSearch::Paths</a>
+      </li>
+    </ul>
+  </div>
   <h2 id="methods">Methods
   </h2>
   <h3 id="Google__Cloud__Vision__V1__ProductSearch__Paths_location_path_instance_" data-uid="Google::Cloud::Vision::V1::ProductSearch::Paths#location_path(instance)" class="notranslate">#location_path</h3>

--- a/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
@@ -180,6 +180,20 @@
   </ul>
 </div>
 {{/includedBy.0}}
+{{#includedIn.0}}
+<div class="inheritance">
+  <h2>{{__global.includedIn}}</h2>
+  <ul>
+{{/includedIn.0}}
+{{#includedIn}}
+    <li>
+      {{{.}}}
+    </li>
+{{/includedIn}}
+{{#includedIn.0}}
+  </ul>
+</div>
+{{/includedIn.0}}
 {{#example.0}}
 <h2>{{__global.example}}{{#example.1}}s{{/example.1}}</h2>
 {{/example.0}}


### PR DESCRIPTION
Add in the template for `includedIn` content. Verified with the previous Ruby lead that the content is expected to show.

Content is based on the following YAML: https://github.com/googleapis/doc-pipeline/blob/9dd2737e1f8bfa9e5d19e791fc86809755e98a19/testdata/ruby/Google-Cloud-Vision-V1-ImageAnnotator-Paths.yml#L18-L20

* Exists as list entries
* Found in the header

Fixes b/343552210.