### PR TITLE
chore: update to add header for enums

### DIFF
--- a/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
@@ -2,7 +2,7 @@
 
 {{>partials/uref/class.header}}
 {{#children}}
-<h2 id="{{id}}">{{>partials/classSubtitle}}</h2>
+<h2 id="{{id}}">{{#inEnum}}{{__global.enum}}{{/inEnum}}{{^inEnum}}{{>partials/classSubtitle}}{{/inEnum}}</h2>
 {{#children}}
 {{^_disableContribution}}
 {{#docurl}}


### PR DESCRIPTION
Header value for enums weren't populating. Couldn't add testdata but verified locally that it correctly adds enum header and only for enums.

Towards b/451717676. 