### PR TITLE
chore: add metadata for code snippets

### DIFF
--- a/testdata/goldens/go/control/apiv2.html
+++ b/testdata/goldens/go/control/apiv2.html
@@ -292,7 +292,7 @@ The returned client must be Closed when it is done being used to clean up its un
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -348,7 +348,7 @@ namespace enabled bucket.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -393,7 +393,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -439,7 +439,7 @@ hierarchical namespace enabled bucket.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -482,7 +482,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -526,7 +526,7 @@ applicable to a hierarchical namespace enabled bucket.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -571,7 +571,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -616,7 +616,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -662,7 +662,7 @@ hierarchical namespace enabled bucket.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -712,7 +712,7 @@ func main() {
   </div>
     <h5 class="notranslate">all</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -758,7 +758,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -808,7 +808,7 @@ func main() {
   </div>
     <h5 class="notranslate">all</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -857,7 +857,7 @@ completes.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;

--- a/testdata/goldens/go/dataflux.html
+++ b/testdata/goldens/go/dataflux.html
@@ -35,7 +35,7 @@ initialize it with NewLister() instead of creating it directly.</p>
         <div class="markdown level1 conceptual"></div>
           <h3>Example</h3>
         <div class="codewrapper">
-        <pre class="prettyprint"><code>package main
+        <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;

--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -487,7 +487,7 @@ which uses the Client&#39;s credentials to handle authentication.</p>
         <div class="markdown level1 conceptual"></div>
           <h4>Example</h4>
         <div class="codewrapper">
-        <pre class="prettyprint"><code>package main
+        <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;fmt&quot;
@@ -609,7 +609,7 @@ Selecting a specific generation of an object is not currently supported by the c
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -640,7 +640,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -674,7 +674,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1087,7 +1087,7 @@ Use Client.Bucket to get a handle.</p>
           <h3>Example</h3>
           <h4 class="notranslate">exists</h4>
         <div class="codewrapper">
-        <pre class="prettyprint"><code>package main
+        <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1140,7 +1140,7 @@ Note: gRPC is not supported.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1178,7 +1178,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1220,7 +1220,7 @@ If attrs is nil the API defaults will be used.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1260,7 +1260,7 @@ This call does not perform any network operations.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1291,7 +1291,7 @@ Note: gRPC is not supported.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1368,7 +1368,7 @@ subject to any SLA or deprecation policy.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1408,7 +1408,7 @@ Note: gRPC is not supported.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1460,7 +1460,7 @@ lexicographically by name.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1532,7 +1532,7 @@ for this method.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1559,7 +1559,7 @@ func main() {
   </div>
     <h5 class="notranslate">readModifyWrite</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1631,7 +1631,7 @@ calls will return iterator.Done.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1779,7 +1779,7 @@ package. You may also use options defined in this package, such as [WithJSONRead
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1807,7 +1807,7 @@ func main() {
   </div>
     <h5 class="notranslate">unauthenticated</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1875,7 +1875,7 @@ are returned.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1914,7 +1914,7 @@ Note: gRPC is not supported.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1957,7 +1957,7 @@ Note: gRPC is not supported.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -1989,7 +1989,7 @@ func main() {
   </div>
     <h5 class="notranslate">forServiceAccountEmail</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -2021,7 +2021,7 @@ func main() {
   </div>
     <h5 class="notranslate">showDeletedKeys</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -2106,7 +2106,7 @@ these options.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -2246,7 +2246,7 @@ for details on how these operate.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -2284,7 +2284,7 @@ func main() {
   </div>
     <h5 class="notranslate">progress</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -2404,7 +2404,7 @@ Note: gRPC is not supported.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -2441,7 +2441,7 @@ Note: gRPC is not supported.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -2476,7 +2476,7 @@ Note: gRPC is not supported.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3109,7 +3109,7 @@ Use BucketHandle.Object to get a handle.</p>
           <h3>Example</h3>
           <h4 class="notranslate">exists</h4>
         <div class="codewrapper">
-        <pre class="prettyprint"><code>package main
+        <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3160,7 +3160,7 @@ ErrObjectNotExist will be returned if the object is not found.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3185,7 +3185,7 @@ func main() {
   </div>
     <h5 class="notranslate">withConditions</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3254,7 +3254,7 @@ in which case the user project of src is billed.</p>
               <h4>Example</h4>
     <h5 class="notranslate">rotateEncryptionKeys</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3290,7 +3290,7 @@ func main() {
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3344,7 +3344,7 @@ endpoints at <a href="https://cloud.google.com/storage/docs/json_api/">https://c
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3392,7 +3392,7 @@ for more details.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3452,7 +3452,7 @@ See <a href="https://cloud.google.com/storage/docs/encryption">https://cloud.goo
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3529,7 +3529,7 @@ release.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3562,7 +3562,7 @@ func main() {
   </div>
     <h5 class="notranslate">lastNBytes</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3595,7 +3595,7 @@ func main() {
   </div>
     <h5 class="notranslate">untilEnd</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3644,7 +3644,7 @@ release.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3696,7 +3696,7 @@ stop writing without saving the data, cancel the context.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3737,7 +3737,7 @@ the first time nor for extending the RetainUntil time.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3837,7 +3837,7 @@ ErrObjectNotExist will be returned if the object is not found.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -3897,7 +3897,7 @@ represent prefixes.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -4018,7 +4018,7 @@ method which uses the Client&#39;s credentials to handle authentication.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Example</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;bytes&quot;
@@ -5106,7 +5106,7 @@ Writer.ChunkSize has been set to zero.</p>
             <div class="markdown level1 conceptual"></div>
               <h4>Examples</h4>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -5138,7 +5138,7 @@ func main() {
   </div>
     <h5 class="notranslate">checksum</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -5172,7 +5172,7 @@ func main() {
   </div>
     <h5 class="notranslate">timeout</h5>
   <div class="codewrapper">
-  <pre class="prettyprint"><code>package main
+  <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;

--- a/testdata/goldens/go/transfermanager.html
+++ b/testdata/goldens/go/transfermanager.html
@@ -218,7 +218,7 @@ Google Cloud Storage dictates.</p>
           <h3>Examples</h3>
           <h4 class="notranslate">asynchronous</h4>
         <div class="codewrapper">
-        <pre class="prettyprint"><code>package main
+        <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;
@@ -286,7 +286,7 @@ func main() {
         </div>
           <h4 class="notranslate">synchronous</h4>
         <div class="codewrapper">
-        <pre class="prettyprint"><code>package main
+        <pre class="prettyprint" data-code-snippet="true"><code>package main
 
 import (
 	&quot;context&quot;

--- a/testdata/goldens/ruby/Google-Cloud-Vision-V1-ImageAnnotator-Client.html
+++ b/testdata/goldens/ruby/Google-Cloud-Vision-V1-ImageAnnotator-Client.html
@@ -87,7 +87,7 @@ images per page. Progress and results can be retrieved through the
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def async_batch_annotate_files(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def async_batch_annotate_files(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>async_batch_annotate_files</code> via a request object, either of type
@@ -106,7 +106,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def async_batch_annotate_files(requests: nil, parent: nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def async_batch_annotate_files(requests: nil, parent: nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>async_batch_annotate_files</code> via keyword arguments. Note that at
@@ -210,7 +210,7 @@ GCS bucket, each json file containing BatchAnnotateImagesResponse proto.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def async_batch_annotate_images(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def async_batch_annotate_images(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>async_batch_annotate_images</code> via a request object, either of type
@@ -229,7 +229,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def async_batch_annotate_images(requests: nil, output_config: nil, parent: nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def async_batch_annotate_images(requests: nil, output_config: nil, parent: nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>async_batch_annotate_images</code> via keyword arguments. Note that at
@@ -334,7 +334,7 @@ extracted.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def batch_annotate_files(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::BatchAnnotateFilesResponse</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def batch_annotate_files(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::BatchAnnotateFilesResponse</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>batch_annotate_files</code> via a request object, either of type
@@ -353,7 +353,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def batch_annotate_files(requests: nil, parent: nil) -&gt; ::Google::Cloud::Vision::V1::BatchAnnotateFilesResponse</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def batch_annotate_files(requests: nil, parent: nil) -&gt; ::Google::Cloud::Vision::V1::BatchAnnotateFilesResponse</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>batch_annotate_files</code> via keyword arguments. Note that at
@@ -444,7 +444,7 @@ def batch_annotate_images(requests: nil, parent: nil) -&gt; ::Google::Cloud::Vis
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def batch_annotate_images(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::BatchAnnotateImagesResponse</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def batch_annotate_images(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::BatchAnnotateImagesResponse</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>batch_annotate_images</code> via a request object, either of type
@@ -463,7 +463,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def batch_annotate_images(requests: nil, parent: nil) -&gt; ::Google::Cloud::Vision::V1::BatchAnnotateImagesResponse</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def batch_annotate_images(requests: nil, parent: nil) -&gt; ::Google::Cloud::Vision::V1::BatchAnnotateImagesResponse</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>batch_annotate_images</code> via keyword arguments. Note that at

--- a/testdata/goldens/ruby/Google-Cloud-Vision-V1-ImageAnnotator-Operations.html
+++ b/testdata/goldens/ruby/Google-Cloud-Vision-V1-ImageAnnotator-Operations.html
@@ -72,7 +72,7 @@ corresponding to <code>Code.CANCELLED</code>.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def cancel_operation(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def cancel_operation(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>cancel_operation</code> via a request object, either of type
@@ -91,7 +91,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def cancel_operation(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def cancel_operation(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>cancel_operation</code> via keyword arguments. Note that at
@@ -203,7 +203,7 @@ operation. If the server doesn&#39;t support this method, it returns
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_operation(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_operation(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_operation</code> via a request object, either of type
@@ -222,7 +222,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_operation(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_operation(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_operation</code> via keyword arguments. Note that at
@@ -300,7 +300,7 @@ service.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_operation(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_operation(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_operation</code> via a request object, either of type
@@ -319,7 +319,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_operation(name: nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_operation(name: nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_operation</code> via keyword arguments. Note that at
@@ -440,7 +440,7 @@ is the parent resource, without the operations collection id.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_operations(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Gapic::Operation&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_operations(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Gapic::Operation&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_operations</code> via a request object, either of type
@@ -459,7 +459,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_operations(name: nil, filter: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Gapic::Operation&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_operations(name: nil, filter: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Gapic::Operation&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_operations</code> via keyword arguments. Note that at
@@ -558,7 +558,7 @@ immediate response is no guarantee that the operation is done.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def wait_operation(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def wait_operation(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>wait_operation</code> via a request object, either of type
@@ -577,7 +577,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def wait_operation(name: nil, timeout: nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def wait_operation(name: nil, timeout: nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>wait_operation</code> via keyword arguments. Note that at

--- a/testdata/goldens/ruby/Google-Cloud-Vision-V1-ProductSearch-Client.html
+++ b/testdata/goldens/ruby/Google-Cloud-Vision-V1-ProductSearch-Client.html
@@ -104,7 +104,7 @@ present, no change is made.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def add_product_to_product_set(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def add_product_to_product_set(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>add_product_to_product_set</code> via a request object, either of type
@@ -123,7 +123,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def add_product_to_product_set(name: nil, product: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def add_product_to_product_set(name: nil, product: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>add_product_to_product_set</code> via keyword arguments. Note that at
@@ -252,7 +252,7 @@ characters.</li>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def create_product(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def create_product(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>create_product</code> via a request object, either of type
@@ -271,7 +271,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def create_product(parent: nil, product: nil, product_id: nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def create_product(parent: nil, product: nil, product_id: nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>create_product</code> via keyword arguments. Note that at
@@ -365,7 +365,7 @@ def create_product_set(parent: nil, product_set: nil, product_set_id: nil) -&gt;
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def create_product_set(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def create_product_set(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>create_product_set</code> via a request object, either of type
@@ -384,7 +384,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def create_product_set(parent: nil, product_set: nil, product_set_id: nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def create_product_set(parent: nil, product_set: nil, product_set_id: nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>create_product_set</code> via keyword arguments. Note that at
@@ -490,7 +490,7 @@ compatible with the parent product&#39;s product_category is detected.</li>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def create_reference_image(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceImage</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def create_reference_image(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceImage</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>create_reference_image</code> via a request object, either of type
@@ -509,7 +509,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceImage</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceImage</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>create_reference_image</code> via keyword arguments. Note that at
@@ -601,7 +601,7 @@ until all related caches are refreshed.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_product(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_product(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_product</code> via a request object, either of type
@@ -620,7 +620,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_product(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_product(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_product</code> via keyword arguments. Note that at
@@ -701,7 +701,7 @@ ProductSet are not deleted.</p><p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_product_set(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_product_set(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_product_set</code> via a request object, either of type
@@ -720,7 +720,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_product_set(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_product_set(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_product_set</code> via keyword arguments. Note that at
@@ -804,7 +804,7 @@ caches are refreshed.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_reference_image(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_reference_image(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_reference_image</code> via a request object, either of type
@@ -823,7 +823,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_reference_image(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_reference_image(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_reference_image</code> via keyword arguments. Note that at
@@ -907,7 +907,7 @@ def get_product(name: nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pr
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_product(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_product(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_product</code> via a request object, either of type
@@ -926,7 +926,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_product(name: nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_product(name: nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_product</code> via keyword arguments. Note that at
@@ -1010,7 +1010,7 @@ def get_product_set(name: nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</co
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_product_set(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_product_set(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_product_set</code> via a request object, either of type
@@ -1029,7 +1029,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_product_set(name: nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_product_set(name: nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_product_set</code> via keyword arguments. Note that at
@@ -1113,7 +1113,7 @@ def get_reference_image(name: nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceI
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_reference_image(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceImage</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_reference_image(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceImage</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_reference_image</code> via a request object, either of type
@@ -1132,7 +1132,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_reference_image(name: nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceImage</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_reference_image(name: nil) -&gt; ::Google::Cloud::Vision::V1::ReferenceImage</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_reference_image</code> via keyword arguments. Note that at
@@ -1220,7 +1220,7 @@ For the format of the csv file please see
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def import_product_sets(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def import_product_sets(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>import_product_sets</code> via a request object, either of type
@@ -1239,7 +1239,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def import_product_sets(parent: nil, input_config: nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def import_product_sets(parent: nil, input_config: nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>import_product_sets</code> via keyword arguments. Note that at
@@ -1372,7 +1372,7 @@ than 1.</li>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_product_sets(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::ProductSet&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_product_sets(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::ProductSet&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_product_sets</code> via a request object, either of type
@@ -1391,7 +1391,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_product_sets(parent: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::ProductSet&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_product_sets(parent: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::ProductSet&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_product_sets</code> via keyword arguments. Note that at
@@ -1486,7 +1486,7 @@ def list_products(parent: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::P
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_products(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::Product&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_products(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::Product&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_products</code> via a request object, either of type
@@ -1505,7 +1505,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_products(parent: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::Product&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_products(parent: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::Product&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_products</code> via keyword arguments. Note that at
@@ -1603,7 +1603,7 @@ empty.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_products_in_product_set(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::Product&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_products_in_product_set(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::Product&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_products_in_product_set</code> via a request object, either of type
@@ -1622,7 +1622,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_products_in_product_set(name: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::Product&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_products_in_product_set(name: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::Product&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_products_in_product_set</code> via keyword arguments. Note that at
@@ -1720,7 +1720,7 @@ than 1.</li>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_reference_images(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::ReferenceImage&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_reference_images(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::ReferenceImage&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_reference_images</code> via a request object, either of type
@@ -1739,7 +1739,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_reference_images(parent: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::ReferenceImage&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_reference_images(parent: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Google::Cloud::Vision::V1::ReferenceImage&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_reference_images</code> via keyword arguments. Note that at
@@ -1869,7 +1869,7 @@ progress and results of the request.
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def purge_products(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def purge_products(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>purge_products</code> via a request object, either of type
@@ -1888,7 +1888,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def purge_products(product_set_purge_config: nil, delete_orphan_products: nil, parent: nil, force: nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def purge_products(product_set_purge_config: nil, delete_orphan_products: nil, parent: nil, force: nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>purge_products</code> via keyword arguments. Note that at
@@ -1984,7 +1984,7 @@ def remove_product_from_product_set(name: nil, product: nil) -&gt; ::Google::Pro
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def remove_product_from_product_set(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def remove_product_from_product_set(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>remove_product_from_product_set</code> via a request object, either of type
@@ -2003,7 +2003,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def remove_product_from_product_set(name: nil, product: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def remove_product_from_product_set(name: nil, product: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>remove_product_from_product_set</code> via keyword arguments. Note that at
@@ -2103,7 +2103,7 @@ longer than 4096 characters.</li>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def update_product(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def update_product(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>update_product</code> via a request object, either of type
@@ -2122,7 +2122,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def update_product(product: nil, update_mask: nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def update_product(product: nil, update_mask: nil) -&gt; ::Google::Cloud::Vision::V1::Product</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>update_product</code> via keyword arguments. Note that at
@@ -2214,7 +2214,7 @@ missing from the request or longer than 4096 characters.</li>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def update_product_set(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def update_product_set(request, options = nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>update_product_set</code> via a request object, either of type
@@ -2233,7 +2233,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def update_product_set(product_set: nil, update_mask: nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def update_product_set(product_set: nil, update_mask: nil) -&gt; ::Google::Cloud::Vision::V1::ProductSet</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>update_product_set</code> via keyword arguments. Note that at

--- a/testdata/goldens/ruby/Google-Cloud-Vision-V1-ProductSearch-Operations.html
+++ b/testdata/goldens/ruby/Google-Cloud-Vision-V1-ProductSearch-Operations.html
@@ -72,7 +72,7 @@ corresponding to <code>Code.CANCELLED</code>.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def cancel_operation(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def cancel_operation(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>cancel_operation</code> via a request object, either of type
@@ -91,7 +91,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def cancel_operation(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def cancel_operation(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>cancel_operation</code> via keyword arguments. Note that at
@@ -203,7 +203,7 @@ operation. If the server doesn&#39;t support this method, it returns
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_operation(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_operation(request, options = nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_operation</code> via a request object, either of type
@@ -222,7 +222,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def delete_operation(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def delete_operation(name: nil) -&gt; ::Google::Protobuf::Empty</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>delete_operation</code> via keyword arguments. Note that at
@@ -300,7 +300,7 @@ service.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_operation(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_operation(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_operation</code> via a request object, either of type
@@ -319,7 +319,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def get_operation(name: nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def get_operation(name: nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>get_operation</code> via keyword arguments. Note that at
@@ -440,7 +440,7 @@ is the parent resource, without the operations collection id.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_operations(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Gapic::Operation&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_operations(request, options = nil) -&gt; ::Gapic::PagedEnumerable&lt;::Gapic::Operation&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_operations</code> via a request object, either of type
@@ -459,7 +459,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def list_operations(name: nil, filter: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Gapic::Operation&gt;</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def list_operations(name: nil, filter: nil, page_size: nil, page_token: nil) -&gt; ::Gapic::PagedEnumerable&lt;::Gapic::Operation&gt;</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>list_operations</code> via keyword arguments. Note that at
@@ -558,7 +558,7 @@ immediate response is no guarantee that the operation is done.</p>
   <div class="level1 summary">
     <strong>Overloads</strong>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def wait_operation(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def wait_operation(request, options = nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>wait_operation</code> via a request object, either of type
@@ -577,7 +577,7 @@ parameters, or to keep all the default parameter values, pass an empty Hash.
     </ul>
   </div>
     <div class="codewrapper">
-      <pre class="prettyprint"><code>def wait_operation(name: nil, timeout: nil) -&gt; ::Gapic::Operation</code></pre>
+      <pre class="prettyprint" data-code-snippet="true"><code>def wait_operation(name: nil, timeout: nil) -&gt; ::Gapic::Operation</code></pre>
     </div>
     <div class="level1 summary">
       Pass arguments to <code>wait_operation</code> via keyword arguments. Note that at

--- a/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
@@ -129,7 +129,7 @@
 {{/overloads.0}}
 {{#overloads}}
   <div class="codewrapper">
-    <pre class="prettyprint"><code>{{content}}</code></pre>
+    <pre class="prettyprint" data-code-snippet="true"><code>{{content}}</code></pre>
   </div>
   <div class="level1 summary">
     {{{description}}}

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.examples.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.examples.tmpl.partial
@@ -24,7 +24,7 @@
 {{/name.0}}
 {{/name}}
 <div class="codewrapper">
-<pre class="prettyprint"><code>{{content}}</code></pre>
+<pre class="prettyprint" data-code-snippet="true"><code>{{content}}</code></pre>
 </div>
 {{/codeexamples}}
 {{#example}}


### PR DESCRIPTION
Adds metadata for code snippets for internal tracking. This should only be added for meaningful code snippets, so they are excluded from small codeblocks like syntaxes.

There are other metadata we could add but hard to do so at doc-pipeline level.

Fixes b/267215050.