### PR TITLE
chore: update gsutil to gcloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here's how it works in `doc-pipeline`:
 1. When we convert the YAML to HTML, we upload two things:
    1. The resulting HTML content (in a tarball).
    1. The xref map file to the `xrefs` directory of the bucket. You can see them
-      all using `gsutil ls gs://docs-staging-v2/xrefs`.
+      all using `gcloud storage ls gs://docs-staging-v2/xrefs`.
 1. You can use the `xref-services` argument for `docuploader create-metadata`
    to refer to
    [cross reference services](https://dotnet.github.io/docfx/tutorial/links_and_cross_references.html#cross-reference-services).
@@ -188,7 +188,7 @@ black docpipeline tests
 
 1. Create a Cloud Storage bucket and add a `docfx-*.tgz` file. For example:
    ```
-   gsutil cp gs://docs-staging-v2-dev/docfx-nodejs-scheduler-2.1.1.tar.gz gs://my-bucket
+   gcloud storage cp gs://docs-staging-v2-dev/docfx-nodejs-scheduler-2.1.1.tar.gz gs://my-bucket
    ```
 1. Copy a service account with permission to access `my-bucket` to
    `/dev/shm/73713_docuploader_service_account`.

--- a/ci/trampoline_v2.sh
+++ b/ci/trampoline_v2.sh
@@ -26,8 +26,8 @@
 # To run this script, first download few files from gcs to /dev/shm.
 # (/dev/shm is passed into the container as KOKORO_GFILE_DIR).
 #
-# gsutil cp gs://cloud-devrel-kokoro-resources/python-docs-samples/secrets_viewer_service_account.json /dev/shm
-# gsutil cp gs://cloud-devrel-kokoro-resources/python-docs-samples/automl_secrets.txt /dev/shm
+# gcloud storage cp gs://cloud-devrel-kokoro-resources/python-docs-samples/secrets_viewer_service_account.json /dev/shm
+# gcloud storage cp gs://cloud-devrel-kokoro-resources/python-docs-samples/automl_secrets.txt /dev/shm
 #
 # Then run the script.
 # .kokoro/trampoline_v2.sh

--- a/delete.sh
+++ b/delete.sh
@@ -22,7 +22,7 @@ fi
 
 gcloud auth activate-service-account --key-file $KOKORO_KEYSTORE_DIR/73713_docuploader_service_account
 
-MATCHING_BLOBS=$(gsutil ls "$BLOB_TO_DELETE")
+MATCHING_BLOBS=$(gcloud storage ls "$BLOB_TO_DELETE")
 NUM_BLOBS=$(echo "$MATCHING_BLOBS" | wc -l)
 
 if [ $NUM_BLOBS -gt 1 ]; then
@@ -30,4 +30,4 @@ if [ $NUM_BLOBS -gt 1 ]; then
   exit 2
 fi
 
-gsutil rm "$BLOB_TO_DELETE"
+gcloud storage rm "$BLOB_TO_DELETE"


### PR DESCRIPTION
`gsutil` has been deprecated, preferred to use `gcloud storage`. See https://cloud.google.com/storage/docs/gsutil.