### PR TITLE
build: limit DocFX parallelism for Go blobs

### DIFF
--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -202,8 +202,13 @@ def build_and_format(
     site_path = tmp_path.joinpath("site")
 
     log.info(f"Running `docfx build` for {blob_name} in {tmp_path}...")
+    exec_options = ["docfx", "build", "-t", f"{TEMPLATE_DIR.absolute()}"]
+    if blob_name.removeprefix("docfx-").startswith("go-"):
+        # Go blobs don't need parallelism, removing it will speed up DocFX
+        # builds.
+        exec_options.extend(["--maxParallelism", "1"])
     shell.run(
-        ["docfx", "build", "--maxParallelism", "1", "-t", f"{TEMPLATE_DIR.absolute()}"],
+        exec_options,
         cwd=tmp_path,
         hide_output=False,
     )

--- a/docpipeline/generate.py
+++ b/docpipeline/generate.py
@@ -203,7 +203,7 @@ def build_and_format(
 
     log.info(f"Running `docfx build` for {blob_name} in {tmp_path}...")
     shell.run(
-        ["docfx", "build", "-t", f"{TEMPLATE_DIR.absolute()}"],
+        ["docfx", "build", "--maxParallelism", "1", "-t", f"{TEMPLATE_DIR.absolute()}"],
         cwd=tmp_path,
         hide_output=False,
     )


### PR DESCRIPTION
Noticed that Go blobs can take a very long time to finish builds. Tested with a Go blob and noticed the runtime go down from 4 hours to 2 hours. 

This will only help for Go blobs as parallelism might be needed for other blobs, but for Go blobs there's only few pages so parallelism isn't necessary and unhelpful when the single page is few MB big.

See b/495855332 for context.

Fixed b/495855332.