### PR TITLE
ci: remove unused secrets from kokoro config

### DIFF
--- a/ci/common.cfg
+++ b/ci/common.cfg
@@ -49,13 +49,4 @@ env_vars: {
     value: "doc-pipeline-test"
 }
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "docuploader_service_account"
-    }
-  }
-}
-
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"


### PR DESCRIPTION
Removing unused docuploader_service_account and yoshi-automation-github-key from Kokoro configurations.