### PR TITLE
feat: Add the implements section to the documentation

### DIFF
--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents an AppEngineHttpTarget.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.iappenginehttptarget.html">google.cloud.scheduler.v1.IAppEngineHttpTarget</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents an AppEngineRouting.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.iappenginerouting.html">google.cloud.scheduler.v1.IAppEngineRouting</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a CreateJobRequest.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.icreatejobrequest.html">google.cloud.scheduler.v1.ICreateJobRequest</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a DeleteJobRequest.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ideletejobrequest.html">google.cloud.scheduler.v1.IDeleteJobRequest</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a GetJobRequest.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.igetjobrequest.html">google.cloud.scheduler.v1.IGetJobRequest</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a HttpTarget.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ihttptarget.html">google.cloud.scheduler.v1.IHttpTarget</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a Job.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ijob.html">google.cloud.scheduler.v1.IJob</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a ListJobsRequest.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ilistjobsrequest.html">google.cloud.scheduler.v1.IListJobsRequest</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a ListJobsResponse.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ilistjobsresponse.html">google.cloud.scheduler.v1.IListJobsResponse</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a OAuthToken.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ioauthtoken.html">google.cloud.scheduler.v1.IOAuthToken</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents an OidcToken.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ioidctoken.html">google.cloud.scheduler.v1.IOidcToken</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a PauseJobRequest.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ipausejobrequest.html">google.cloud.scheduler.v1.IPauseJobRequest</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a PubsubTarget.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.ipubsubtarget.html">google.cloud.scheduler.v1.IPubsubTarget</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a ResumeJobRequest.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.iresumejobrequest.html">google.cloud.scheduler.v1.IResumeJobRequest</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a RetryConfig.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.iretryconfig.html">google.cloud.scheduler.v1.IRetryConfig</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents a RunJobRequest.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.irunjobrequest.html">google.cloud.scheduler.v1.IRunJobRequest</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
@@ -13,6 +13,8 @@
   
   <div class="markdown level0 summary"><p>Represents an UpdateJobRequest.</p>
 </div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="google.cloud.scheduler.v1.iupdatejobrequest.html">google.cloud.scheduler.v1.IUpdateJobRequest</a></div>
   <h2>Package</h2>
   <span class="xref">@google-cloud/scheduler!</span>
   <h2 id="constructors">Constructors

--- a/testdata/goldens/php/V1.ImageAnnotatorClient.html
+++ b/testdata/goldens/php/V1.ImageAnnotatorClient.html
@@ -49,6 +49,8 @@ try {
     $imageAnnotatorClient-&gt;close();
 }
 </code></pre></div>
+  <h2>Implements</h2>
+      <div><a class="xref" href="V1.ImageContext.html">ImageContext</a></div>
   <h2 id="methods">Methods
   </h2>
   <h3 id="_Google_Cloud_Vision_V1_ImageAnnotatorClient__createImageObject__" data-uid="\Google\Cloud\Vision\V1\ImageAnnotatorClient::createImageObject()" class="notranslate">createImageObject</h3>

--- a/testdata/php/V1.ImageAnnotatorClient.yml
+++ b/testdata/php/V1.ImageAnnotatorClient.yml
@@ -49,6 +49,8 @@ items:
     type: class
     langs:
       - php
+    implements:
+      - \Google\Cloud\Vision\V1\ImageContext
     children:
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::createImageObject()'
       - '\Google\Cloud\Vision\V1\ImageAnnotatorClient::annotateImage()'

--- a/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
@@ -116,6 +116,14 @@
 <h2>{{__global.namespace}}</h2>
 {{{value.specName.0.value}}}
 {{/namespace.0}}
+{{#implements.0}}
+<h2>{{__global.implements}}</h2>
+{{/implements.0}}
+{{#implements}}
+  {{#value}}
+    <div><xref uid="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+  {{/value}}
+{{/implements}}
 {{#package.0}}
 <h2>{{__global.package}}</h2>
 {{{value.specName.0.value}}}


### PR DESCRIPTION
Add the missing `Implements` section to the template. Now the classes should point to the interfaces that the class is implementing.