### PR TITLE
feat: Update configuration to use Application Default Credentials

### DIFF
--- a/ci/common.cfg
+++ b/ci/common.cfg
@@ -18,7 +18,7 @@
 timeout_mins: 600
 
 # Use the trampoline script to run in docker.
-build_file: "doc-pipeline/ci/trampoline_v2.sh"
+build_file: "doc-pipeline/ci/run_tests.sh"
 
 # Copy results for Resultstore
 action {
@@ -49,13 +49,8 @@ env_vars: {
     value: "doc-pipeline-test"
 }
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "docuploader_service_account"
-    }
-  }
-}
-
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+container_properties {
+  docker_image: "us-central1-docker.pkg.dev/kokoro-container-bakery/kokoro/ubuntu/ubuntu2204/full:current"
+}


### PR DESCRIPTION
Changed the following settings:

* Updated the `build_file` field to the script referenced by `TRAMPOLINE_BUILD_FILE`.
* Removed the `before_action` section to stop getting service account keys from Keystore.
* Added a `container_properties` section to specify the Docker image to use.

The next PR will clean up the remaining Trampoline items such as environment variables.