### PR TITLE
fix: Update the current directory to the repo directory in the tests script

### DIFF
--- a/ci/common.cfg
+++ b/ci/common.cfg
@@ -18,7 +18,7 @@
 timeout_mins: 600
 
 # Use the trampoline script to run in docker.
-build_file: "doc-pipeline/ci/trampoline_v2.sh"
+build_file: "doc-pipeline/ci/run_tests.sh"
 
 # Copy results for Resultstore
 action {
@@ -49,13 +49,8 @@ env_vars: {
     value: "doc-pipeline-test"
 }
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "docuploader_service_account"
-    }
-  }
-}
-
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+container_properties {
+  docker_image: "us-central1-docker.pkg.dev/kokoro-container-bakery/kokoro/ubuntu/ubuntu2204/full:current"
+}

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -30,6 +30,9 @@ export GOOGLE_APPLICATION_CREDENTIALS=$KOKORO_KEYSTORE_DIR/73713_docuploader_ser
 # Add the path where pip installs commands to PATH.
 export PATH=$PATH:${HOME}/.local/bin
 
+# Change the current directory to the repo directory.
+cd github/doc-pipeline
+
 python3 -m pip install -e .
 # Install lint dependencies. types-protobuf is needed for mypy.
 python3 -m pip install -r requirements.txt


### PR DESCRIPTION
The build is failing due to the test script not finding the `setup.py` file. It looks like the script just needs to move to the `github/doc-pipeline` directory before executing tests.