### PR TITLE
feat: Remove usage of exported service account key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,6 @@ You can generate DocFX YAML using language-specific generators.
 Here is how to use doc-pipeline. All of the steps except the credential setup
 should be automated/scripted as part of the release process.
 
-1. Fetch the credentials to be able to upload to the bucket. Add the following
-   to your Kokoro build config:
-   ```
-   before_action {
-      fetch_keystore {
-         keystore_resource {
-            keystore_config_id: 73713
-            keyname: "docuploader_service_account"
-         }
-      }
-   }
-   ```
 1. Generate DocFX YAML. Usually, this is done as part of the library release
    process.
 
@@ -48,7 +36,7 @@ should be automated/scripted as part of the release process.
    ```
    docuploader create-metadata
    ```
-   
+
    Add flags to specify the language, package, version etc. See
    [`docuploader`](https://pypi.org/project/gcp-docuploader).
 1. Upload the YAML with the `docfx` prefix:
@@ -159,7 +147,7 @@ black docpipeline tests
       1. ```
          black --check tests
          flake8 tests
-         GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json TEST_BUCKET=my-bucket pytest tests
+         TEST_BUCKET=my-bucket pytest tests
          ```
       1. To update goldens add the `--update-goldens` flag:
          ```

--- a/ci/common.cfg
+++ b/ci/common.cfg
@@ -49,13 +49,4 @@ env_vars: {
     value: "doc-pipeline-test"
 }
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "docuploader_service_account"
-    }
-  }
-}
-
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -23,10 +23,6 @@ fi
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
-# If running locally, copy a service account file to
-# /dev/shm/73713_docuploader_service_account before calling ci/trampoline_v2.sh.
-export GOOGLE_APPLICATION_CREDENTIALS=$KOKORO_KEYSTORE_DIR/73713_docuploader_service_account
-
 # Add the path where pip installs commands to PATH.
 export PATH=$PATH:${HOME}/.local/bin
 

--- a/docpipeline/__main__.py
+++ b/docpipeline/__main__.py
@@ -18,7 +18,6 @@ import shutil
 import sys
 
 import click
-import docuploader.credentials
 from docuploader import log
 from google.cloud import storage
 
@@ -50,8 +49,7 @@ def main():
 @click.argument("bucket_name")
 def build_new_docs(bucket_name: str) -> None:
     verify()
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
-    storage_client = storage.Client(project=project_id, credentials=credentials)
+    storage_client = storage.Client()
 
     try:
         generate.build_new_docs(bucket_name, storage_client)
@@ -64,8 +62,7 @@ def build_new_docs(bucket_name: str) -> None:
 @click.argument("bucket_name")
 def build_all_docs(bucket_name: str) -> None:
     verify()
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
-    storage_client = storage.Client(project=project_id, credentials=credentials)
+    storage_client = storage.Client()
 
     try:
         generate.build_all_docs(bucket_name, storage_client)
@@ -78,8 +75,7 @@ def build_all_docs(bucket_name: str) -> None:
 @click.argument("bucket_name")
 def build_latest_docs(bucket_name: str) -> None:
     verify()
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
-    storage_client = storage.Client(project=project_id, credentials=credentials)
+    storage_client = storage.Client()
     only_latest = True
 
     try:
@@ -94,8 +90,7 @@ def build_latest_docs(bucket_name: str) -> None:
 @click.argument("object_name")
 def build_one_doc(bucket_name: str, object_name: str) -> None:
     verify()
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
-    storage_client = storage.Client(project=project_id, credentials=credentials)
+    storage_client = storage.Client()
 
     try:
         generate.build_one_doc(bucket_name, object_name, storage_client)
@@ -109,8 +104,7 @@ def build_one_doc(bucket_name: str, object_name: str) -> None:
 @click.argument("language")
 def build_language_docs(bucket_name: str, language: str) -> None:
     verify()
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
-    storage_client = storage.Client(project=project_id, credentials=credentials)
+    storage_client = storage.Client()
 
     try:
         generate.build_language_docs(bucket_name, language, storage_client)
@@ -124,8 +118,7 @@ def build_language_docs(bucket_name: str, language: str) -> None:
 @click.argument("language")
 def build_latest_language_docs(bucket_name: str, language: str) -> None:
     verify()
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
-    storage_client = storage.Client(project=project_id, credentials=credentials)
+    storage_client = storage.Client()
     only_latest = True
 
     try:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -20,7 +20,6 @@ import shutil
 import tempfile
 import unittest
 
-import docuploader.credentials
 from docuploader import shell, tar
 from docuploader.protos import metadata_pb2
 from google.cloud import storage
@@ -114,9 +113,7 @@ def init_test():
     if not test_bucket:
         pytest.skip("must set TEST_BUCKET")
 
-    credentials, project_id = docuploader.credentials.find(credentials_file="")
-
-    storage_client = storage.Client(project=project_id, credentials=credentials)
+    storage_client = storage.Client()
 
     return test_bucket, storage_client
 


### PR DESCRIPTION
Removing the `GOOGLE_APPLICATION_CREDENTIALS` environment variable and usage of the exported service account key.

The pipeline falls back to using the attached service account, which has permissions on the test and production buckets.